### PR TITLE
Improve testing

### DIFF
--- a/bin/run_tests.R
+++ b/bin/run_tests.R
@@ -21,15 +21,23 @@ test_exercise <- function(exercise) {
   
 }
 
-# create temp directory for testing purposes
-temp_dir <- "temp" 
-dir.create(temp_dir)
-setwd(temp_dir)
+run_tests <- function() {
 
-# read config and test all exercises
-config <- fromJSON(file.path("..", "config.json"))
-lapply(config$exercises$slug, test_exercise)
+  # create temp directory for testing purposes
+  temp_dir <- "temp" 
+  dir.create(temp_dir)
+  setwd(temp_dir)
+  
+  on.exit({
+    # clean up on exit
+    setwd(dir = "../")
+    unlink("temp", recursive = TRUE)
+  })
+  
+  # read config and test all exercises
+  config <- fromJSON(file.path("..", "config.json"))
+  lapply(config$exercises$slug, test_exercise)
+    
+}
 
-# clean up
-setwd(dir = "../")
-unlink("temp", recursive = TRUE)
+run_tests()

--- a/exercises/anagram/test_anagram.R
+++ b/exercises/anagram/test_anagram.R
@@ -128,4 +128,4 @@ test_that("anagrams must use all letters exactly once", {
                c())
 })
 
-print("All tests passed for exercise: anagram")
+message("All tests passed for exercise: anagram")

--- a/exercises/bob/test_bob.R
+++ b/exercises/bob/test_bob.R
@@ -161,4 +161,4 @@ test_that("non-question ending with whitespace", {
                "Whatever.")
 })
 
-print("All tests passed for exercise: bob")
+message("All tests passed for exercise: bob")

--- a/exercises/difference-of-squares/test_difference-of-squares.R
+++ b/exercises/difference-of-squares/test_difference-of-squares.R
@@ -21,4 +21,4 @@ test_that("difference of squares 100", {
   expect_equal(difference_of_squares(input), 25164150)
 })
 
-print("All tests passed for exercise: difference-of-squares")
+message("All tests passed for exercise: difference-of-squares")

--- a/exercises/grains/test_grains.R
+++ b/exercises/grains/test_grains.R
@@ -45,4 +45,4 @@ test_that("returns the total number of square on the board", {
   expect_equal(total(), 18446744073709551615)
 })
 
-print("All tests passed for exercise: grains")
+message("All tests passed for exercise: grains")

--- a/exercises/hamming/test_hamming.R
+++ b/exercises/hamming/test_hamming.R
@@ -85,4 +85,4 @@ test_that("disallow second strand longer", {
   expect_error(hamming(strand1, strand2))
 })
 
-print("All tests passed for exercise: hamming")
+message("All tests passed for exercise: hamming")

--- a/exercises/hello-world/test_hello-world.R
+++ b/exercises/hello-world/test_hello-world.R
@@ -13,4 +13,4 @@ test_that("other sample name", {
   expect_equal(hello_world("Bob"), "Hello, Bob!")
 })
 
-print("All tests passed for exercise: hello-world")
+message("All tests passed for exercise: hello-world")

--- a/exercises/isogram/test_isogram.R
+++ b/exercises/isogram/test_isogram.R
@@ -41,4 +41,4 @@ test_that("made-up name that is an isogram", {
   expect_equal(is_isogram(word), TRUE)
 })
 
-print("All tests passed for exercise: isogram")
+message("All tests passed for exercise: isogram")

--- a/exercises/largest-series-product/test_largest-series-product.R
+++ b/exercises/largest-series-product/test_largest-series-product.R
@@ -107,4 +107,4 @@ test_that("rejects negative span", {
   expect_error(largest_series_product(digits, span))
 })
 
-print("All tests passed for exercise: largest-series-product")
+message("All tests passed for exercise: largest-series-product")

--- a/exercises/leap/test_leap.R
+++ b/exercises/leap/test_leap.R
@@ -21,4 +21,4 @@ test_that("year divisible by 400: leap year", {
   expect_equal(leap(year), TRUE)
 })
 
-print("All tests passed for exercise: leap")
+message("All tests passed for exercise: leap")

--- a/exercises/luhn/test_luhn.R
+++ b/exercises/luhn/test_luhn.R
@@ -71,4 +71,4 @@ test_that("nine doubled is nine", {
   expect_equal(is_valid(input), TRUE)
 })
 
-print("All tests passed for exercise: luhn")
+message("All tests passed for exercise: luhn")

--- a/exercises/pascals-triangle/test_pascals-triangle.R
+++ b/exercises/pascals-triangle/test_pascals-triangle.R
@@ -29,4 +29,4 @@ test_that("null/no rows", {
   expect_error(pascals_triangle(NULL))
 })
 
-print("All tests passed for exercise: pascals-triangle")
+message("All tests passed for exercise: pascals-triangle")

--- a/exercises/perfect-numbers/test_perfect-numbers.R
+++ b/exercises/perfect-numbers/test_perfect-numbers.R
@@ -56,4 +56,4 @@ test_that("seventh perfect number", {
   expect_equal(is_perfect(n), TRUE)
 })
 
-print("All tests passed for exercise: perfect-numbers")
+message("All tests passed for exercise: perfect-numbers")

--- a/exercises/phone-number/test_phone-number.R
+++ b/exercises/phone-number/test_phone-number.R
@@ -45,4 +45,4 @@ test_that("invalid if exchange code does not start with 2-9", {
   expect_equal(parse_phone_number("(223) 056-7890"), NULL)
 })
 
-print("All tests passed for exercise: phone-number")
+message("All tests passed for exercise: phone-number")

--- a/exercises/prime-factors/test_prime-factors.R
+++ b/exercises/prime-factors/test_prime-factors.R
@@ -44,4 +44,4 @@ test_that("factors include a large prime", {
                c(11, 9539, 894119))
 })
 
-print("All tests passed for exercise: prime-factors")
+message("All tests passed for exercise: prime-factors")

--- a/exercises/raindrops/test_raindrops.R
+++ b/exercises/raindrops/test_raindrops.R
@@ -92,4 +92,4 @@ test_that("the sound for 3125 is Plang as it has a factor 5", {
   expect_equal(raindrops(number), "Plang")
 })
 
-print("All tests passed for exercise: raindrops")
+message("All tests passed for exercise: raindrops")

--- a/exercises/rna-transcription/test_rna-transcription.R
+++ b/exercises/rna-transcription/test_rna-transcription.R
@@ -41,4 +41,4 @@ test_that("dna correctly handles partially invalid input", {
   expect_error(to_rna(dna))
 })
 
-print("All tests passed for exercise: rna-transcription")
+message("All tests passed for exercise: rna-transcription")

--- a/exercises/rotational-cipher/test_rotational-cipher.R
+++ b/exercises/rotational-cipher/test_rotational-cipher.R
@@ -62,4 +62,4 @@ test_that("rotate all letters", {
                "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.")
 })
 
-print("All tests passed for exercise: rotational-cipher")
+message("All tests passed for exercise: rotational-cipher")

--- a/exercises/scrabble-score/test_scrabble-score.R
+++ b/exercises/scrabble-score/test_scrabble-score.R
@@ -56,4 +56,4 @@ test_that("entire alphabet available", {
   expect_equal(scrabble_score(input), 87)
 })
 
-print("All tests passed for exercise: scrabble-score")
+message("All tests passed for exercise: scrabble-score")

--- a/exercises/secret-handshake/test_secret-handshake.R
+++ b/exercises/secret-handshake/test_secret-handshake.R
@@ -51,4 +51,4 @@ test_that("do nothing if lower 5 bits not set", {
   expect_equal(handshake(32), c())
 })
 
-print("All tests passed for exercise: secret-handshake")
+message("All tests passed for exercise: secret-handshake")

--- a/exercises/sieve/test_sieve.R
+++ b/exercises/sieve/test_sieve.R
@@ -35,4 +35,4 @@ test_that("find primes up to 1000", {
                  967, 971, 977, 983, 991, 997))
 })
 
-print("All tests passed for exercise: sieve")
+message("All tests passed for exercise: sieve")

--- a/exercises/space-age/test_space-age.R
+++ b/exercises/space-age/test_space-age.R
@@ -41,4 +41,4 @@ test_that("Age on Neptune", {
   expect_equal(space_age(seconds, "neptune"), 1.58)
 })
 
-print("All tests passed for exercise: space-age")
+message("All tests passed for exercise: space-age")

--- a/exercises/sum-of-multiples/test_sum-of-multiples.R
+++ b/exercises/sum-of-multiples/test_sum-of-multiples.R
@@ -49,4 +49,4 @@ test_that("Case 12", {
   expect_equal(sum_of_multiples(c(), 10000), 0)
 })
 
-print("All tests passed for exercise: sum-of-multiples")
+message("All tests passed for exercise: sum-of-multiples")

--- a/exercises/tournament/test_tournament.R
+++ b/exercises/tournament/test_tournament.R
@@ -172,4 +172,4 @@ test_that("invalid match result", {
                ))
 })
 
-print("All tests passed for exercise: tournament")
+message("All tests passed for exercise: tournament")

--- a/exercises/word-count/test_word-count.R
+++ b/exercises/word-count/test_word-count.R
@@ -67,4 +67,4 @@ test_that("normalize case", {
                      list("go" = 3, "stop" = 2))
 })
 
-print("All tests passed for exercise: word-count")
+message("All tests passed for exercise: word-count")


### PR DESCRIPTION
Use `on.exit()` to improve behaviour of `run_tests`
Use `message` instead of `print` in test output