### PR TITLE
remove dependency and speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
 - R -e "install.packages('jsonlite')"
 - R -e "install.packages('lintr')"
 - R -e "install.packages('magrittr')"
-- R -e "install.packages('dplyr')"
 script:
 - bin/fetch-configlet
 - bin/configlet .

--- a/exercises/perfect-numbers/example.R
+++ b/exercises/perfect-numbers/example.R
@@ -27,10 +27,12 @@ is_perfect <- function(n){
   
   sum <- sum(find_factors(n)) + 1
   
-  # alternative to multiple if/else statements
-  type <- dplyr::case_when(sum == n ~ "perfect",
-                             sum > n ~ "abundant",
-                             sum < n ~ "deficient")
+  if (sum == n)
+    return("perfect")
+  else-if (sum > n)
+    return("abundant")
+  else-if (sum < n)
+    return("deficient")
   
-  type
+  # alternative to multiple if/else-if predicates: dplyr::case_when()
 }


### PR DESCRIPTION
I now think that [introducing](https://github.com/exercism/r/pull/57/files) [dplyr](http://dplyr.tidyverse.org/) was not a good idea, because Travis builds [take](https://travis-ci.org/exercism/r/builds/248425754) [longer](https://travis-ci.org/exercism/r/builds/245459496) and because a comment can also hint at other solution patterns.