### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ install:
 - R -e "install.packages('magrittr')"
 script:
 - bin/fetch-configlet
-- bin/configlet .
+- bin/configlet lint .
 - R -e "source('bin/run_tests.R')"
 - R -e "source('bin/run_lints.R')"


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23