### PR TITLE
rename function to avoid implication of return data type

### DIFF
--- a/exercises/perfect-numbers/example.R
+++ b/exercises/perfect-numbers/example.R
@@ -1,4 +1,4 @@
-is_perfect <- function(n){
+number_type <- function(n){
   
   # catch invalid input
   if (n <= 0)

--- a/exercises/perfect-numbers/perfect-numbers.R
+++ b/exercises/perfect-numbers/perfect-numbers.R
@@ -1,3 +1,3 @@
-is_perfect <- function(n){
+number_type <- function(n){
   
 }

--- a/exercises/perfect-numbers/test_perfect-numbers.R
+++ b/exercises/perfect-numbers/test_perfect-numbers.R
@@ -3,73 +3,73 @@ library(testthat)
 
 test_that("Smallest perfect number is classified correctly", {
   n <- 6
-  expect_equal(is_perfect(n), "perfect")
+  expect_equal(number_type(n), "perfect")
 })
 
 test_that("Medium perfect number is classified correctly", {
   n <- 28
-  expect_equal(is_perfect(n), "perfect")
+  expect_equal(number_type(n), "perfect")
 })
 
 test_that("Large perfect number is classified correctly", {
   n <- 33550336
-  expect_equal(is_perfect(n), "perfect")
+  expect_equal(number_type(n), "perfect")
 })
 
 
 
 test_that("Smallest abundant number is classified correctly", {
   n <- 12
-  expect_equal(is_perfect(n), "abundant")
+  expect_equal(number_type(n), "abundant")
 })
 
 test_that("Medium abundant number is classified correctly", {
   n <- 30
-  expect_equal(is_perfect(n), "abundant")
+  expect_equal(number_type(n), "abundant")
 })
 
 test_that("Large abundant number is classified correctly", {
   n <- 33550335
-  expect_equal(is_perfect(n), "abundant")
+  expect_equal(number_type(n), "abundant")
 })
 
 
 
 test_that("Smallest prime deficient number is classified correctly", {
   n <- 2
-  expect_equal(is_perfect(n), "deficient")
+  expect_equal(number_type(n), "deficient")
 })
 
 test_that("Smallest non-prime deficient number is classified correctly", {
   n <- 4
-  expect_equal(is_perfect(n), "deficient")
+  expect_equal(number_type(n), "deficient")
 })
 
 test_that("Medium deficient number is classified correctly", {
   n <- 32
-  expect_equal(is_perfect(n), "deficient")
+  expect_equal(number_type(n), "deficient")
 })
 
 test_that("Large deficient number is classified correctly", {
   n <- 33550337
-  expect_equal(is_perfect(n), "deficient")
+  expect_equal(number_type(n), "deficient")
 })
 
 test_that("Edge case (no factors other than itself) is classified correctly", {
   n <- 1
-  expect_equal(is_perfect(n), "deficient")
+  expect_equal(number_type(n), "deficient")
 })
 
 
 
 test_that("Zero is rejected (not a natural number)", {
   n <- 0
-  expect_error(is_perfect(n))
+  expect_error(number_type(n))
 })
 
 test_that("Negative integer is rejected (not a natural number)", {
   n <- -1
-  expect_error(is_perfect(n))
+  expect_error(number_type(n))
 })
 
 


### PR DESCRIPTION
[A discussion](http://exercism.io/submissions/d82550c3cf0940adb302e1c00d7c2c65) revealed, that `is_` as a function name prefix can be understood as implying a boolean return value. [Our Pythonistas](https://github.com/exercism/python/blob/master/exercises/perfect-numbers/perfect_numbers_test.py) for example have set up their tests in that way. We could also align ours, but as a quick fix, here's a more neutral naming suggestion.