### PR TITLE
hello-world: Fix tests to match README.md

### DIFF
--- a/exercises/hello-world/test_hello-world.R
+++ b/exercises/hello-world/test_hello-world.R
@@ -5,12 +5,4 @@ test_that("no name", {
   expect_equal(hello_world(), "Hello, World!")
 })
 
-test_that("sample name", {
-  expect_equal(hello_world("Alice"), "Hello, Alice!")
-})
-
-test_that("other sample name", {
-  expect_equal(hello_world("Bob"), "Hello, Bob!")
-})
-
 message("All tests passed for exercise: hello-world")


### PR DESCRIPTION
Remove tests that call hello-world with arguments.

Closes #82