### PR TITLE
Inline the exercise README insert

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -4,10 +4,15 @@
 {{- with .Hints }}
 {{ . }}
 {{ end }}
-{{- with .TrackInsert }}
-{{ . }}
-{{ end }}
-{{- with .Spec.Credits -}}
+## Installation
+See [this guide](https://github.com/exercism/xr/blob/master/docs/INSTALLATION.md) for instructions on how to setup your local R environment.
+
+## How to implement your solution
+In each problem folder, there is a file named `<exercise_name>.R` containing a function that returns a `NULL` value. Place your implementation inside the body of the function.
+
+## How to run tests
+Inside of RStudio, simply execute the `test_<exercise_name>.R` script. This can be conveniently done with [testthat's `auto_test` function](https://www.rdocumentation.org/packages/testthat/topics/auto_test). Because exercism code and tests are in the same folder, use this same path for both  `code_path` and `test_path` parameters. On the command-line, you can also run `Rscript test_<exercise_name>.R`.
+{{ with .Spec.Credits }}
 ## Source
 
 {{ . }}

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -1,8 +1,0 @@
-## Installation
-See [this guide](https://github.com/exercism/xr/blob/master/docs/INSTALLATION.md) for instructions on how to setup your local R environment.
-
-## How to implement your solution
-In each problem folder, there is a file named `<exercise_name>.R` containing a function that returns a `NULL` value. Place your implementation inside the body of the function.
-
-## How to run tests
-Inside of RStudio, simply execute the `test_<exercise_name>.R` script. This can be conveniently done with [testthat's `auto_test` function](https://www.rdocumentation.org/packages/testthat/topics/auto_test). Because exercism code and tests are in the same folder, use this same path for both  `code_path` and `test_path` parameters. On the command-line, you can also run `Rscript test_<exercise_name>.R`.

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -29,7 +29,6 @@ allergens that score 256, 512, 1024, etc.).  Your program should
 ignore those components of the score.  For example, if the allergy
 score is 257, your program should only report the eggs (1) allergy.
 
-
 ## Installation
 See [this guide](https://github.com/exercism/xr/blob/master/docs/INSTALLATION.md) for instructions on how to setup your local R environment.
 

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,10 +1,10 @@
 # Beer Song
 
-Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
+Recite the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
 
 Note that not all verses are identical.
 
-```plain
+```text
 99 bottles of beer on the wall, 99 bottles of beer.
 Take one down and pass it around, 98 bottles of beer on the wall.
 

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -10,6 +10,7 @@ always reach 1 eventually.
 Given a number n, return the number of steps required to reach 1.
 
 ## Examples
+
 Starting with n = 12, the steps would be as follows:
 
 0. 12
@@ -24,7 +25,6 @@ Starting with n = 12, the steps would be as follows:
 9. 1
 
 Resulting in 9 steps. So for input n = 12, the return value would be 9.
-
 
 ## Installation
 See [this guide](https://github.com/exercism/xr/blob/master/docs/INSTALLATION.md) for instructions on how to setup your local R environment.

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -1,7 +1,7 @@
 # Diamond
 
-The diamond kata takes as its input a letter, and outputs it in a diamond 
-shape. Given a letter, it prints a diamond starting with 'A', with the 
+The diamond kata takes as its input a letter, and outputs it in a diamond
+shape. Given a letter, it prints a diamond starting with 'A', with the
 supplied letter at the widest point.
 
 ## Requirements
@@ -15,7 +15,7 @@ supplied letter at the widest point.
 * The diamond has a square shape (width equals height).
 * The letters form a diamond shape.
 * The top half has the letters in ascending order.
-* The bottom half has the letters in descending order. 
+* The bottom half has the letters in descending order.
 * The four corners (containing the spaces) are triangles.
 
 ## Examples
@@ -24,13 +24,13 @@ In the following examples, spaces are indicated by `·` characters.
 
 Diamond for letter 'A':
 
-```plain
+```text
 A
 ```
 
 Diamond for letter 'C':
 
-```plain
+```text
 ··A··
 ·B·B·
 C···C
@@ -40,7 +40,7 @@ C···C
 
 Diamond for letter 'E':
 
-```plain
+```text
 ····A····
 ···B·B···
 ··C···C··

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -15,7 +15,6 @@ Write code that shows:
 - how many grains were on each square, and
 - the total number of grains
 
-
 ## For bonus points
 
 Did you get the tests passing and the code clean? If you want to, these

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -2,13 +2,14 @@
 
 Determine if a word or phrase is an isogram.
 
-An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter.
+An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter, however spaces and hyphens are allowed to appear multiple times.
 
 Examples of isograms:
 
 - lumberjacks
 - background
 - downstream
+- six-year-old
 
 The word *isograms*, however, is not an isogram, because the s repeats.
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -4,7 +4,7 @@ Given a year, report if it is a leap year.
 
 The tricky thing here is that a leap year in the Gregorian calendar occurs:
 
-```plain
+```text
 on every year that is evenly divisible by 4
   except every year that is evenly divisible by 100
     unless the year is also evenly divisible by 400

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -18,27 +18,27 @@ are disallowed.
 
 ## Example 1: valid credit card number
 
-```
+```text
 4539 1488 0343 6467
 ```
 
 The first step of the Luhn algorithm is to double every second digit,
 starting from the right. We will be doubling
 
-```
+```text
 4_3_ 1_8_ 0_4_ 6_6_
 ```
 
 If doubling the number results in a number greater than 9 then subtract 9
 from the product. The results of our doubling:
 
-```
+```text
 8569 2478 0383 3437
 ```
 
 Then sum all of the digits:
 
-```
+```text
 8+5+6+9+2+4+7+8+0+3+8+3+3+4+3+7 = 80
 ```
 
@@ -46,19 +46,19 @@ If the sum is evenly divisible by 10, then the number is valid. This number is v
 
 ## Example 2: invalid credit card number
 
-```
+```text
 8273 1232 7352 0569
 ```
 
 Double the second digits, starting from the right
 
-```
+```text
 7253 2262 5312 0539
 ```
 
 Sum the digits
 
-```
+```text
 7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
 ```
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,30 +1,16 @@
 # Nucleotide Count
 
-Given a DNA string, compute how many times each nucleotide occurs in the string.
+Given a single stranded DNA string, compute how many times each nucleotide occurs in the string.
 
-DNA is represented by an alphabet of the following symbols: 'A', 'C',
-'G', and 'T'.
+The genetic language of every living thing on the planet is DNA.
+DNA is a large molecule that is built from an extremely long sequence of individual elements called nucleotides.
+4 types exist in DNA and these differ only slightly and can be represented as the following symbols: 'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' thymine.
 
-Each symbol represents a nucleotide, which is a fancy name for the
-particular molecules that happen to make up a large part of DNA.
-
-Shortest intro to biochemistry EVAR:
-
+Here is an analogy:
 - twigs are to birds nests as
-- nucleotides are to DNA and RNA as
-- amino acids are to proteins as
-- sugar is to starch as
-- oh crap lipids
-
-I'm not going to talk about lipids because they're crazy complex.
-
-So back to nucleotides.
-
-DNA contains four types of them: adenine (`A`), cytosine (`C`), guanine
-(`G`), and thymine (`T`).
-
-RNA contains a slightly different set of nucleotides, but we don't care
-about that for now.
+- nucleotides are to DNA as
+- legos are to lego houses as
+- words are to sentences as...
 
 ## Installation
 See [this guide](https://github.com/exercism/xr/blob/master/docs/INSTALLATION.md) for instructions on how to setup your local R environment.

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -2,7 +2,7 @@
 
 Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
 "every letter") is a sentence using every letter of the alphabet at least once.
-The best known English pangram is: 
+The best known English pangram is:
 > The quick brown fox jumps over the lazy dog.
 
 The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -1,11 +1,11 @@
-# Pascals Triangle
+# Pascal's Triangle
 
 Compute Pascal's triangle up to a given number of rows.
 
 In Pascal's Triangle each number is computed by adding the numbers to
 the right and left of the current position in the previous row.
 
-```plain
+```text
     1
    1 1
   1 2 1

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -5,7 +5,7 @@ Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
 
 The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
-- **Perfect**: aliquot sum = number 
+- **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6
   - 28 is a perfect number because (1 + 2 + 4 + 7 + 14) = 28
 - **Abundant**: aliquot sum > number
@@ -14,7 +14,7 @@ The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) d
 - **Deficient**: aliquot sum < number
   - 8 is a deficient number because (1 + 2 + 4) = 7
   - Prime numbers are deficient
-  
+
 Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
 
 ## Installation

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -6,14 +6,15 @@ The **North American Numbering Plan (NANP)** is a telephone numbering system use
 
 NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
 
-
 The format is usually represented as
-```
+
+```text
 (NXX)-NXX-XXXX
 ```
+
 where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
 
-Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.
+Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
 
 For example, the inputs
 - `+1 (613)-995-0253`

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,4 +1,4 @@
-# Rna Transcription
+# RNA Transcription
 
 Given a DNA strand, return its RNA complement (per RNA transcription).
 
@@ -29,7 +29,7 @@ Inside of RStudio, simply execute the `test_<exercise_name>.R` script. This can 
 
 ## Source
 
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -13,7 +13,7 @@ The most commonly used rotational cipher is `ROT13`.
 
 A `ROT13` on the Latin alphabet would be as follows:
 
-```plain
+```text
 Plain:  abcdefghijklmnopqrstuvwxyz
 Cipher: nopqrstuvwxyzabcdefghijklm
 ```
@@ -23,6 +23,7 @@ It is stronger than the Atbash cipher because it has 27 possible keys, and 25 us
 Ciphertext is written out in the same formatting as the input including spaces and punctuation.
 
 ## Examples
+
 - ROT5  `omg` gives `trl`
 - ROT0  `c` gives `c`
 - ROT26 `Cool` gives `Cool`

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -6,7 +6,7 @@ Given a word, compute the scrabble score for that word.
 
 You'll need these:
 
-```plain
+```text
 Letter                           Value
 A, E, I, O, U, L, N, R, S, T       1
 D, G                               2
@@ -18,6 +18,7 @@ Q, Z                               10
 ```
 
 ## Examples
+
 "cabbage" should be scored as worth 14 points:
 
 - 3 points for C
@@ -34,6 +35,7 @@ And to total:
 - = 14
 
 ## Extensions
+
 - You can play a double or a triple letter.
 - You can play a double or a triple word.
 

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -6,7 +6,7 @@
 You and your fellow cohort of those in the "know" when it comes to
 binary decide to come up with a secret "handshake".
 
-```
+```text
 1 = wink
 10 = double blink
 100 = close your eyes
@@ -39,7 +39,7 @@ Inside of RStudio, simply execute the `test_<exercise_name>.R` script. This can 
 
 ## Source
 
-Bert, in Mary Poppins [http://www.imdb.com/character/ch0011238/quotes](http://www.imdb.com/character/ch0011238/quotes)
+Bert, in Mary Poppins [http://www.imdb.com/title/tt0058331/quotes/qt0437047](http://www.imdb.com/title/tt0058331/quotes/qt0437047)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -12,7 +12,7 @@ Given an age in seconds, calculate how old someone would be on:
    - Neptune: orbital period 164.79132 Earth years
 
 So if you were told someone were 1,000,000,000 seconds old, you should
-be able to say that they're 31 Earth-years old.
+be able to say that they're 31.69 Earth-years old.
 
 If you're wondering why Pluto didn't make the cut, go watch [this
 youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,15 +1,12 @@
 # Sum Of Multiples
 
-Given a number, find the sum of all the multiples of particular numbers up to
+Given a number, find the sum of all the unique multiples of particular numbers up to
 but not including that number.
 
-If we list all the natural numbers up to but not including 20 that are
-multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
+If we list all the natural numbers below 20 that are multiples of 3 or 5,
+we get 3, 5, 6, 9, 10, 12, 15, and 18.
 
 The sum of these multiples is 78.
-
-Given a number, find the sum of the multiples of a given set of numbers,
-up to but not including that number.
 
 ## Installation
 See [this guide](https://github.com/exercism/xr/blob/master/docs/INSTALLATION.md) for instructions on how to setup your local R environment.

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -5,7 +5,7 @@ Tally the results of a small football competition.
 Based on an input file containing which team played against which and what the
 outcome was, create a file with a table like this:
 
-```
+```text
 Team                           | MP |  W |  D |  L |  P
 Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
 Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
@@ -31,7 +31,7 @@ Input
 
 Your tallying program will receive input that looks like:
 
-```
+```text
 Allegoric Alaskans;Blithering Badgers;win
 Devastating Donkeys;Courageous Californians;draw
 Devastating Donkeys;Allegoric Alaskans;win
@@ -42,7 +42,7 @@ Allegoric Alaskans;Courageous Californians;win
 
 The result of the match refers to the first team listed. So this line
 
-```
+```text
 Allegoric Alaskans;Blithering Badgers;win
 ```
 
@@ -50,7 +50,7 @@ Means that the Allegoric Alaskans beat the Blithering Badgers.
 
 This line:
 
-```
+```text
 Courageous Californians;Blithering Badgers;loss
 ```
 
@@ -58,7 +58,7 @@ Means that the Blithering Badgers beat the Courageous Californians.
 
 And this line:
 
-```
+```text
 Devastating Donkeys;Courageous Californians;draw
 ```
 

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -73,6 +73,5 @@ In each problem folder, there is a file named `<exercise_name>.R` containing a f
 ## How to run tests
 Inside of RStudio, simply execute the `test_<exercise_name>.R` script. This can be conveniently done with [testthat's `auto_test` function](https://www.rdocumentation.org/packages/testthat/topics/auto_test). Because exercism code and tests are in the same folder, use this same path for both  `code_path` and `test_path` parameters. On the command-line, you can also run `Rscript test_<exercise_name>.R`.
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -2,23 +2,26 @@
 
 Determine if a triangle is equilateral, isosceles, or scalene.
 
-An _equilateral_ triangle has all three sides the same length.<br/>
+An _equilateral_ triangle has all three sides the same length.
+
 An _isosceles_ triangle has at least two sides the same length. (It is sometimes
 specified as having exactly two sides the same length, but for the purposes of
-this exercise we'll say at least two.)<br/>
+this exercise we'll say at least two.)
+
 A _scalene_ triangle has all sides of different lengths.
 
 ## Note
 
-For a shape to be a triangle at all, all sides have to be of length > 0, and 
-the sum of the lengths of any two sides must be greater than or equal to the 
+For a shape to be a triangle at all, all sides have to be of length > 0, and
+the sum of the lengths of any two sides must be greater than or equal to the
 length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
 
 ## Dig Deeper
 
-The case where the sum of the lengths of two sides _equals_ that of the 
-third is known as a _degenerate_ triangle - it has zero area and looks like 
+The case where the sum of the lengths of two sides _equals_ that of the
+third is known as a _degenerate_ triangle - it has zero area and looks like
 a single line. Feel free to add your own code/tests to check for degenerate triangles.
+
 
 ## Hint
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -4,13 +4,12 @@ Given a phrase, count the occurrences of each word in that phrase.
 
 For example for the input `"olly olly in come free"`
 
-```plain
+```text
 olly: 2
 in: 1
 come: 1
 free: 1
 ```
-
 
 ## Installation
 See [this guide](https://github.com/exercism/xr/blob/master/docs/INSTALLATION.md) for instructions on how to setup your local R environment.


### PR DESCRIPTION
Now that we're operating with a track-wide template for generating exercise
READMEs we no longer need a separate markdown document to use for hints
and instructions that apply to all the exercises in a track. These instructions
can be defined directly in the template.

The first commit regenerates the exercise READMEs to pick up tweaks to problem descriptions, which have been updated with various formatting changes, whitespace changes, and clarifications to the description.

That gives us a clean diff when inlining the template and regenerating.

Ref: https://github.com/exercism/meta/issues/94