### PR TITLE
config.json:Fix invalid unlocked_by configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -253,7 +253,7 @@
         "control_flow_conditionals",
         "mathematics"
       ],
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "uuid": "f3e93545-7466-4635-b508-7e02517fdf06"
     },
     {


### PR DESCRIPTION
## Problem
While linting with the latest release of [Configlet](https://github.com/exercism/configlet/releases/tag/v3.8.0) the exercise `pascals-triangle` was found to contain an invalid unlocked_by configuration.

## What's changed
The master config file was updated in the following manner:

1. The `pascals-triangle` exercise no longer has an explicit unlocked_by value. As each core exercise unlocks the next.

## Testing Steps
1. Download the pre-release of Configlet [here](https://github.com/exercism/configlet/releases/tag/v3.8.0)
1. Run `configlet lint <path-to-fsharp-track>`
1. Validate that there are no lint errors.