### PR TITLE
Enable auto_approve for hello-world

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
       "uuid": "285404a4-d8f8-469d-b183-920b08ba2430",
       "core": true,
       "unlocked_by": null,
+      "auto_approve": true,
       "difficulty": 1,
       "topics": [
         "optional_values",


### PR DESCRIPTION
I am unsure whether this is necessary, because #98 has a checkbox for this, but later says `We've currently made any hello-world exercises auto-approved in the backend`.

Either way, shall we set other exercises to `"auto_approve": true`?