### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,8 +7,8 @@
       "slug": "hello-world",
       "uuid": "285404a4-d8f8-469d-b183-920b08ba2430",
       "core": true,
-      "unlocked_by": null,
       "auto_approve": true,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "optional_values",
@@ -57,7 +57,7 @@
       "difficulty": 1,
       "topics": [
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -78,8 +78,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "integers",
-        "mathematics"
+        "integers"
       ]
     },
     {
@@ -122,7 +121,7 @@
       "difficulty": 2,
       "topics": [
         "lists",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -198,7 +197,8 @@
       "difficulty": 2,
       "topics": [
         "control_flow_conditionals",
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -209,7 +209,7 @@
       "difficulty": 3,
       "topics": [
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -220,7 +220,7 @@
       "difficulty": 3,
       "topics": [
         "filtering",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -231,6 +231,7 @@
       "difficulty": 3,
       "topics": [
         "integers",
+        "math",
         "strings",
         "transforming"
       ]
@@ -266,7 +267,7 @@
       "difficulty": 3,
       "topics": [
         "control_flow_conditionals",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -309,8 +310,7 @@
       "unlocked_by": "sum-of-multiples",
       "difficulty": 3,
       "topics": [
-        "classes",
-        "mathematics"
+        "classes"
       ]
     },
     {
@@ -321,6 +321,7 @@
       "difficulty": 2,
       "topics": [
         "control_flow_conditionals",
+        "math",
         "recursion"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110