### PR TITLE
Add vectorised unit test for Collatz Conjecture

### DIFF
--- a/exercises/collatz-conjecture/example.R
+++ b/exercises/collatz-conjecture/example.R
@@ -1,13 +1,15 @@
-collatz_step_counter <- function(num) {
-  
+collatz_scalar <- function(num) {
+
   if (num <= 0) {
     stop("Only positive numbers are allowed")
   } else if (num == 1) {
-    return(0)  
+    return(0)
   } else if (num %% 2 == 0) {
     return(1 + collatz_step_counter(num / 2))
   } else {
     return(1 + collatz_step_counter(3 * num + 1))
   }
-  
+
 }
+
+collatz_step_counter <- Vectorize(collatz_scalar)

--- a/exercises/collatz-conjecture/test_collatz-conjecture.R
+++ b/exercises/collatz-conjecture/test_collatz-conjecture.R
@@ -27,4 +27,9 @@ test_that("Negative input results in an error", {
   expect_error(collatz_step_counter(-15))
 })
 
+test_that("Answer can accept vector parameter", {
+  expect_equal(collatz_step_counter(
+    c(1, 16, 12, 1000000)), (c(0, 4, 9, 152)))
+})
+
 message("All tests passed for exercise: collatz-conjecture")


### PR DESCRIPTION
As a demonstration of the point I raised in issue #109, here is an update for the non-core Collatz Conjecture exercise.  The current version of this does not test for vector parameters and the example would fail this test.

The following changes have been made:
- An extra test has been added to the unit tests that send a four-element vector to the function.
- In the example, the original function `collatz_step_counter` has been renamed to `collatz_scalar`.
- Also in the example, the line `collatz_step_counter <- Vectorize(collatz_scalar)` has been added.

This is a very minor change to the example, but makes the function a lot more powerful by taking full advantage of R's vectorisation capabilities.  R developers really shouldn't be thinking in single values the way most mainstream programming languages do.