### PR TITLE
rotational-cipher: Prevent solutions that simply duplicate the alphabet

### DIFF
--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -4,7 +4,7 @@ Create an implementation of the rotational cipher, also sometimes called the Cae
 
 The Caesar cipher is a simple shift cipher that relies on
 transposing all the letters in the alphabet using an integer key
-between `0` and `26`. Using a key of `0` or `26` will always yield
+(both positive or negative). Using the same key will always yield
 the same output due to modular arithmetic. The letter is shifted
 for as many values as the value of the key.
 
@@ -28,7 +28,9 @@ Ciphertext is written out in the same formatting as the input including spaces a
 - ROT0  `c` gives `c`
 - ROT26 `Cool` gives `Cool`
 - ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
+- ROT39 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
 - ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
+- ROT-13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
 
 ## Installation
 See [this guide](https://exercism.io/tracks/r/installation) for instructions on how to setup your local R environment.

--- a/exercises/rotational-cipher/test_rotational-cipher.R
+++ b/exercises/rotational-cipher/test_rotational-cipher.R
@@ -64,4 +64,18 @@ test_that("rotate all letters", {
                "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.")
 })
 
+test_that("rotate through the alphabet an arbitrary number of times", {
+  text <- "The quick brown fox jumps over the lazy dog."
+  key <- 13 + (123 * 26)
+  expect_equal(rotate(text, key),
+               "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.")
+})
+
+test_that("rotate backwards", {
+  text <- "The quick brown fox jumps over the lazy dog."
+  key <- 13 - (123 * 26)
+  expect_equal(rotate(text, key),
+               "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.")
+})
+
 message("All tests passed for exercise: rotational-cipher")


### PR DESCRIPTION
As discussed in https://github.com/exercism/problem-specifications/pull/1438 and other issues/PRs linked there, I would like to suggest that the R track adds test for rotation keys <0 and >26. What do you think?

Things I am unsure about:

- [ ] [+1 the difficulty](https://github.com/exercism/r/blob/rotate-more-thoroughly/config.json#L164)?
- [ ] bump exercise version?
