### PR TITLE
Adjust core track to help ease bottlenecks

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,17 +38,6 @@
       ]
     },
     {
-      "slug": "hamming",
-      "uuid": "dcc7171a-6b7d-4749-a300-a7270a095486",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "filtering",
-        "strings"
-      ]
-    },
-    {
       "slug": "raindrops",
       "uuid": "955604ef-266f-42c9-abde-ce0fdc2d33ad",
       "core": true,
@@ -60,14 +49,25 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "da01ce65-8c7d-4646-ace4-c067d92f656b",
+      "slug": "hamming",
+      "uuid": "dcc7171a-6b7d-4749-a300-a7270a095486",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "e5166378-e3fc-4393-b4f8-4c36da444c56",
       "core": true,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "control_flow_conditionals",
-        "strings"
+        "parsing",
+        "transforming"
       ]
     },
     {
@@ -93,23 +93,23 @@
       ]
     },
     {
-      "slug": "phone-number",
-      "uuid": "e5166378-e3fc-4393-b4f8-4c36da444c56",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "parsing",
-        "transforming"
-      ]
-    },
-    {
       "slug": "rotational-cipher",
       "uuid": "8bde91c5-2fe7-4f8d-91ec-ed05284b9a49",
       "core": true,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
+        "strings"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "da01ce65-8c7d-4646-ace4-c067d92f656b",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "control_flow_conditionals",
         "strings"
       ]
     },

--- a/config.json
+++ b/config.json
@@ -128,7 +128,7 @@
       "slug": "difference-of-squares",
       "uuid": "6a562684-5938-4ad9-b042-7b44a8cc4561",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 1,
       "topics": [
         "integers",

--- a/config.json
+++ b/config.json
@@ -103,6 +103,17 @@
       ]
     },
     {
+      "slug": "tournament",
+      "uuid": "acf63670-7e56-47c1-9f33-7ec076d5270f",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "parsing",
+        "text_formatting"
+      ]
+    },
+    {
       "slug": "bob",
       "uuid": "da01ce65-8c7d-4646-ace4-c067d92f656b",
       "core": false,
@@ -278,17 +289,6 @@
       "topics": [
         "control_flow_conditionals",
         "math"
-      ]
-    },
-    {
-      "slug": "tournament",
-      "uuid": "acf63670-7e56-47c1-9f33-7ec076d5270f",
-      "core": true,
-      "unlocked_by": "rotational-cipher",
-      "difficulty": 4,
-      "topics": [
-        "parsing",
-        "text_formatting"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -105,8 +105,8 @@
     {
       "slug": "bob",
       "uuid": "da01ce65-8c7d-4646-ace4-c067d92f656b",
-      "core": true,
-      "unlocked_by": null,
+      "core": false,
+      "unlocked_by": "anagram",
       "difficulty": 2,
       "topics": [
         "control_flow_conditionals",
@@ -192,7 +192,7 @@
       "slug": "beer-song",
       "uuid": "3fd2d6dd-6d4d-4b7f-9f1e-0de11899dcb5",
       "core": false,
-      "unlocked_by": "bob",
+      "unlocked_by": "anagram",
       "difficulty": 3,
       "topics": [
         "control_flow_conditionals",
@@ -283,8 +283,8 @@
     {
       "slug": "tournament",
       "uuid": "acf63670-7e56-47c1-9f33-7ec076d5270f",
-      "core": false,
-      "unlocked_by": "phone-number",
+      "core": true,
+      "unlocked_by": "rotational-cipher",
       "difficulty": 4,
       "topics": [
         "parsing",

--- a/config.json
+++ b/config.json
@@ -49,28 +49,6 @@
       ]
     },
     {
-      "slug": "rna-transcription",
-      "uuid": "12e17ede-ff59-45d1-8c66-b07b7ede5702",
-      "core": false,
-      "unlocked_by": "hamming",
-      "difficulty": 1,
-      "topics": [
-        "strings",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "difference-of-squares",
-      "uuid": "6a562684-5938-4ad9-b042-7b44a8cc4561",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "integers",
-        "math"
-      ]
-    },
-    {
       "slug": "raindrops",
       "uuid": "955604ef-266f-42c9-abde-ce0fdc2d33ad",
       "core": true,
@@ -79,16 +57,6 @@
       "topics": [
         "filtering",
         "text_formatting"
-      ]
-    },
-    {
-      "slug": "grains",
-      "uuid": "fb1b7105-98f5-4f4f-8f5c-c410844cc4d3",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "integers"
       ]
     },
     {
@@ -111,27 +79,6 @@
       "topics": [
         "filtering",
         "strings"
-      ]
-    },
-    {
-      "slug": "space-age",
-      "uuid": "b8b3a324-8d62-49d4-ba28-886883e5c549",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "floating_point_numbers"
-      ]
-    },
-    {
-      "slug": "sum-of-multiples",
-      "uuid": "581b968c-f78f-4b60-9eb0-8c73eeeb96af",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "lists",
-        "math"
       ]
     },
     {
@@ -164,6 +111,59 @@
       "difficulty": 3,
       "topics": [
         "strings"
+      ]
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "12e17ede-ff59-45d1-8c66-b07b7ede5702",
+      "core": false,
+      "unlocked_by": "hamming",
+      "difficulty": 1,
+      "topics": [
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "6a562684-5938-4ad9-b042-7b44a8cc4561",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "grains",
+      "uuid": "fb1b7105-98f5-4f4f-8f5c-c410844cc4d3",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "integers"
+      ]
+    },
+    {
+      "slug": "space-age",
+      "uuid": "b8b3a324-8d62-49d4-ba28-886883e5c549",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "floating_point_numbers"
+      ]
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "581b968c-f78f-4b60-9eb0-8c73eeeb96af",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "lists",
+        "math"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -139,7 +139,7 @@
       "slug": "grains",
       "uuid": "fb1b7105-98f5-4f4f-8f5c-c410844cc4d3",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 1,
       "topics": [
         "integers"
@@ -149,7 +149,7 @@
       "slug": "space-age",
       "uuid": "b8b3a324-8d62-49d4-ba28-886883e5c549",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 1,
       "topics": [
         "floating_point_numbers"
@@ -159,7 +159,7 @@
       "slug": "sum-of-multiples",
       "uuid": "581b968c-f78f-4b60-9eb0-8c73eeeb96af",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "anagram",
       "difficulty": 2,
       "topics": [
         "lists",
@@ -215,7 +215,7 @@
       "slug": "prime-factors",
       "uuid": "ee849e23-d709-4e4a-ab89-07a87e13e4fb",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "anagram",
       "difficulty": 3,
       "topics": [
         "integers",
@@ -226,7 +226,7 @@
       "slug": "sieve",
       "uuid": "dabc8218-8ab8-4918-85d3-0afd5b6791c6",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 3,
       "topics": [
         "filtering",
@@ -237,7 +237,7 @@
       "slug": "largest-series-product",
       "uuid": "a1b4bde3-2ee7-42dd-85c5-4303ae546d15",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "rotational-cipher",
       "difficulty": 3,
       "topics": [
         "integers",
@@ -273,7 +273,7 @@
       "slug": "pascals-triangle",
       "uuid": "f3e93545-7466-4635-b508-7e02517fdf06",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "rotational-cipher",
       "difficulty": 3,
       "topics": [
         "control_flow_conditionals",
@@ -317,7 +317,7 @@
       "slug": "triangle",
       "uuid": "d3b2f968-32e2-4df7-a29a-f02ba2c7d581",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "anagram",
       "difficulty": 3,
       "topics": [
         "classes"
@@ -327,7 +327,7 @@
       "slug": "collatz-conjecture",
       "uuid": "4f38e325-587f-4a80-8c8f-6c45ec710e80",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 2,
       "topics": [
         "control_flow_conditionals",
@@ -339,7 +339,7 @@
       "slug": "allergies",
       "uuid": "2f7b585f-f82f-4dca-9588-2df3250184e6",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "hamming",
       "difficulty": 3,
       "topics": [
         "control_flow_conditionals",
@@ -364,7 +364,7 @@
       "slug": "diamond",
       "uuid": "7cad82d6-0db6-d680-4133-81d850d6e7a925454a0",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "rotational-cipher",
       "difficulty": 3,
       "topics": [
         "control_flow_loops",
@@ -375,7 +375,7 @@
       "slug": "acronym",
       "uuid": "54e60174-4833-418c-b9af-2fcb5722b1d6",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "raindrops",
       "difficulty": 1,
       "topics": [
         "filtering",

--- a/config.json
+++ b/config.json
@@ -126,7 +126,7 @@
     {
       "slug": "sum-of-multiples",
       "uuid": "581b968c-f78f-4b60-9eb0-8c73eeeb96af",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
@@ -215,7 +215,7 @@
       "slug": "prime-factors",
       "uuid": "ee849e23-d709-4e4a-ab89-07a87e13e4fb",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "integers",
@@ -226,7 +226,7 @@
       "slug": "sieve",
       "uuid": "dabc8218-8ab8-4918-85d3-0afd5b6791c6",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "filtering",
@@ -236,7 +236,7 @@
     {
       "slug": "largest-series-product",
       "uuid": "a1b4bde3-2ee7-42dd-85c5-4303ae546d15",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
@@ -272,7 +272,7 @@
     {
       "slug": "pascals-triangle",
       "uuid": "f3e93545-7466-4635-b508-7e02517fdf06",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
@@ -317,7 +317,7 @@
       "slug": "triangle",
       "uuid": "d3b2f968-32e2-4df7-a29a-f02ba2c7d581",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "classes"
@@ -327,7 +327,7 @@
       "slug": "collatz-conjecture",
       "uuid": "4f38e325-587f-4a80-8c8f-6c45ec710e80",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "control_flow_conditionals",
@@ -339,7 +339,7 @@
       "slug": "allergies",
       "uuid": "2f7b585f-f82f-4dca-9588-2df3250184e6",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "control_flow_conditionals",
@@ -364,7 +364,7 @@
       "slug": "diamond",
       "uuid": "7cad82d6-0db6-d680-4133-81d850d6e7a925454a0",
       "core": false,
-      "unlocked_by": "pascals-triangle",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "control_flow_loops",


### PR DESCRIPTION
**TL;DR:**
This PR reorders the core exercises; see the end for the new ordering.
Please read the full thing before replying!

---

I wrote a script that takes some data points into account to move certain core exercises to be optional side exercises, and which reorders the remaining exercises.

This is not meant to be the "be all end all" of perfection :-)
This is an attempt to make some simple changes in the short term. In the longer term, over the next 12 months, the product team will be doing a bunch of work to dig into what makes great Exercism exercises, and how to structure tracks to provide a better experience for both learners and mentors.

**Once this goes live** we will continue to monitor the continuation rate, the median wait time, and a few other stats as well, to help decide whether or not we need to take any other immediate steps. That said, if you see anything weird or worrying once the change is out, please ping us on Slack (or here) so we can discuss a fix posthaste!

**The most helpful thing you can do in reviewing this** is to look at the results and tell me whether anything is obviously terrible or suspiciously weird. I know very little about the R track (or the language, for that matter), so I could easily have missed something.

I'd also appreciate it if you posted this to the mentors as a heads up, and also because mentors tend to have a great gut sense about the core exercises.

## Bottleneck detection and fixes
### Removal from core:

The following exercises were moved out of the core track:

- sum-of-multiples
- largest-series-product
- pascals-triangle

This is a list of exercises that typically are unappealing to students and not very interesting to mentor. They tend to be math problems or implementations of CS algorithms and the like.

**Worth considering:** Are any of these exercises particularly valuable in the R track? If so, we should keep it. Let me know and I can regenerate the PR.

### Reordering:

The data that I based the reordering on was taken from the production database, and is based on the last 6 months.

I reordered by taking the original order, and then giving "penalty points" for two different things

- low continuation rates (percentage)
- long wait times in the mentor queue (median wait time in minutes)

"Continuation" is when someone completes an exercise, but then does not submit the following exercise. We have other interesting numbers that we may use to adjust things in the future, but this one seemed like our best bet for now for the bottlenecks. I somewhat arbitrarily chose 75% as the cutoff for whether or not to give penalty points, i.e. continuation rate < 75% gets penalized. The only exercise I did not penalize based on this rate was the exercise directly following `hello-world`, since `hello-world` is basically just a taste test, and it is natural to assume that many people will decide that Exercism is not really for them.

<details>
 <summary>Continuation rates</summary>

```
- hello-world (100%)
- two-fer (69%)
- leap (89%)
- hamming (82%)
- raindrops (88%)
- bob (73%)
- anagram (80%)
- sum-of-multiples (100%)
- word-count (77%)
- phone-number (100%)
- rotational-cipher (78%)
- largest-series-product (83%)
- pascals-triangle (100%)
```

</details>

Long wait times in the mentor queue is an indication that mentors don't enjoy mentoring the exercise, or put it off. This could be for a number of reasons, which we have not explicitly identified, but we've observed that sometimes the exercise is simply too difficult in the current position, which means that mentors have to go back and forth a whole bunch with students to get something right, and the discussions can be quite frustrating. Also sometimes the exercise is just not very interesting to mentor. Or if the exercise is too early in the track sometimes people will submit lots of really complicated solutions rather than a small handful of mostly reasonable solutions, also making it harder to mentor.

So this pushes exercises with long wait times further back in the core track. We may decide that we need to remove some exercises from core altogether, if wait times continue to be bad.

<details>
 <summary>Wait times</summary>

```
- hello-world (0 min)
- two-fer (5666 min)
- leap (478 min)
- hamming (5868 min)
- raindrops (2937 min)
- bob (27236 min)
- anagram (8240 min)
- sum-of-multiples (31500 min)
- word-count (7600 min)
- phone-number (3229 min)
- rotational-cipher (11229 min)
- largest-series-product (4260 min)
- pascals-triangle (2591 min)
```
</details>

### Outcome

#### Before
```
- hello-world
- two-fer
- leap
- hamming
- raindrops
- bob
- anagram
- sum-of-multiples
- word-count
- phone-number
- rotational-cipher
- largest-series-product
- pascals-triangle
```

#### After

_Note: the numbers indicate the position in the core track, as defined by the index of the array. Minus means that it moved earlier, plus means that it moved later._
```
- hello-world
- two-fer
- leap
- raindrops (-1)
- hamming (+1)
- phone-number (-3)
- anagram
- word-count
- rotational-cipher (-1)
- bob (+4)
```
