### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "9881a96d-f5c6-4e0b-9642-1b9be8d385e8",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing R locally",
+      "blurb": "Learn how to install R locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "287ea8e7-9315-49d0-b475-1989c104ef1a",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn R",
+      "blurb": "An overview of how to get started from scratch with R"
+    },
+    {
+      "uuid": "3e7cc698-3941-4c3c-8421-c553acbfad6c",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the R track",
+      "blurb": "Learn how to test your R exercises on Exercism"
+    },
+    {
+      "uuid": "82ca1d57-bb90-4595-a972-13491575508d",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful R resources",
+      "blurb": "A collection of useful resources to help you master R"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
