### PR TITLE
Improve instructions and tests for Anagram exercise

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.md
+++ b/exercises/practice/anagram/.docs/instructions.md
@@ -1,8 +1,10 @@
 # Instructions
 
 An anagram is a rearrangement of letters to form a new word.
-Given a word and a list of candidates, select the sublist of anagrams of the given word.
+Given a word and a vector of candidates, return the subset of anagrams of the given word.
 
-Given `"listen"` and a list of candidates like `"enlists" "google"
-"inlets" "banana"` the program should return a list containing
-`"inlets"`.
+For example, given the subject `"listen"` and a vector of candidates like `"Enlists" "Google"
+"Inlets" "Banana"` the program should return a vector containing
+`"Inlets"`.
+
+Note that the function should not return a candidate if it is the same word as the subject.

--- a/exercises/practice/anagram/test_anagram.R
+++ b/exercises/practice/anagram/test_anagram.R
@@ -6,8 +6,8 @@ context("anagram")
 test_that("no matches", {
   subject <- "diaper"
   candidates <- c("hello", "world", "zombies", "pants")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("detects simple anagram", {
@@ -20,8 +20,8 @@ test_that("detects simple anagram", {
 test_that("does not detect false positives", {
   subject <- "galea"
   candidates <- c("eagle")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("detects multiple anagrams", {
@@ -34,8 +34,8 @@ test_that("detects multiple anagrams", {
 test_that("does not detect anagram subsets", {
   subject <- "good"
   candidates <- c("dog", "goody")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("detects anagram", {
@@ -63,8 +63,8 @@ test_that("does not detect indentical words", {
 test_that("does not detect non-anagrams with identical checksum", {
   subject <- "mass"
   candidates <- c("last")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("detects anagrams case-insensitively", {
@@ -91,43 +91,43 @@ test_that("detects anagrams using case-insensitve possible matches", {
 test_that("does not detect a word as its own anagram", {
   subject <- "banana"
   candidates <- c("Banana")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("does not detect a anagram if the original word is repeated", {
   subject <- "go"
   candidates <- c("go Go GO")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("anagrams must use all letters exactly once", {
   subject <- "tapper"
   candidates <- c("patter")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("eliminates anagrams with the same checksum", {
   subject <- "mass"
   candidates <- c("last")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("capital word is not own anagram", {
   subject <- "BANANA"
   candidates <- c("Banana")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+               0)
 })
 
 test_that("anagrams must use all letters exactly once", {
   subject <- "patter"
   candidates <- c("tapper")
-  expect_equal(anagram(subject, candidates),
-               c())
+  expect_length(anagram(subject, candidates),
+                0)
 })
 
 message("All tests passed for exercise: anagram")


### PR DESCRIPTION
This PR fixes a few things:

* The instructions a clearer, as they now make it obvious that:
   * The output needs to be a vector (not a list)
   * The match needs to be case-insensitive
   * Same words shouldn't be matched
* The tests are now more flexible: they check for a length of 0 for empty vectors, instead of an equality to `c()`. This fixes the issue of users submitting a valid solution that returns an empty vector of mode `character` and having tests failing because of that.