### PR TITLE
armstrong-numbers practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -485,6 +485,18 @@
           "loops",
           "math"
         ]
+      },
+      {
+        "slug": "armstrong-numbers",
+        "name": "Armstrong Numbers",
+        "uuid": "c17ef56b-7418-428b-ac9d-37dbd28de32e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "wip",
+        "topics": [
+          "math"
+        ]
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -492,8 +492,8 @@
         "uuid": "c17ef56b-7418-428b-ac9d-37dbd28de32e",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
-        "status": "wip",
+        "difficulty": 2,
+        "status": "active",
         "topics": [
           "math"
         ]

--- a/exercises/practice/armstrong-numbers/.docs/instructions.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.md
@@ -1,0 +1,14 @@
+# Instructions
+
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
+
+For example:
+
+- 9 is an Armstrong number, because `9 = 9^1 = 9`
+- 10 is *not* an Armstrong number, because `10 != 1^2 + 0^2 = 1`
+- 153 is an Armstrong number, because: `153 = 1^3 + 5^3 + 3^3 = 1 + 125 + 27 = 153`
+- 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
+
+Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": ["colinleach"],
+  "files": {
+    "solution": [
+      "armstrong-numbers.R"
+    ],
+    "test": [
+      "test_armstrong-numbers.R"
+    ],
+    "example": [
+      ".meta/example.R"
+    ]
+  },
+  "blurb": "Determine if a number is an Armstrong number.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"
+}

--- a/exercises/practice/armstrong-numbers/.meta/example.R
+++ b/exercises/practice/armstrong-numbers/.meta/example.R
@@ -1,0 +1,9 @@
+to_digits <- function(n) {
+  chars = n |> as.character() |> strsplit("")
+  as.numeric(chars[[1]])
+}
+
+is_armstrong_number <- function(n) {
+  digits = to_digits(n)
+  sum(digits ^ length(digits)) == n
+}

--- a/exercises/practice/armstrong-numbers/.meta/example.R
+++ b/exercises/practice/armstrong-numbers/.meta/example.R
@@ -1,9 +1,9 @@
 to_digits <- function(n) {
-  chars = n |> as.character() |> strsplit("")
+  chars <- n |> as.character() |> strsplit("")
   as.numeric(chars[[1]])
 }
 
 is_armstrong_number <- function(n) {
-  digits = to_digits(n)
+  digits <- to_digits(n)
   sum(digits ^ length(digits)) == n
 }

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c1ed103c-258d-45b2-be73-d8c6d9580c7b]
+description = "Zero is an Armstrong number"
+
+[579e8f03-9659-4b85-a1a2-d64350f6b17a]
+description = "Single-digit numbers are Armstrong numbers"
+
+[2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
+description = "There are no two-digit Armstrong numbers"
+
+[509c087f-e327-4113-a7d2-26a4e9d18283]
+description = "Three-digit number that is an Armstrong number"
+
+[7154547d-c2ce-468d-b214-4cb953b870cf]
+description = "Three-digit number that is not an Armstrong number"
+
+[6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
+description = "Four-digit number that is an Armstrong number"
+
+[eed4b331-af80-45b5-a80b-19c9ea444b2e]
+description = "Four-digit number that is not an Armstrong number"
+
+[f971ced7-8d68-4758-aea1-d4194900b864]
+description = "Seven-digit number that is an Armstrong number"
+
+[7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
+description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -38,6 +38,8 @@ description = "Seven-digit number that is not an Armstrong number"
 
 [5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
 description = "Armstrong number containing seven zeroes"
+include = false
 
 [12ffbf10-307a-434e-b4ad-c925680e1dd4]
 description = "The largest and last Armstrong number"
+include = false

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.R
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.R
@@ -1,0 +1,3 @@
+is_armstrong_number <- function(n) {
+
+  }

--- a/exercises/practice/armstrong-numbers/test_armstrong-numbers.R
+++ b/exercises/practice/armstrong-numbers/test_armstrong-numbers.R
@@ -39,12 +39,4 @@ test_that("Seven-digit number that is not an Armstrong number", {
   expect_equal(is_armstrong_number(9926314), FALSE)
 })
 
-# test_that("Armstrong number containing seven zeroes", {
-#   expect_equal(is_armstrong_number(186709961001538790100634132976990), TRUE)
-# })
-# 
-# test_that("The largest and last Armstrong number", {
-#   expect_equal(is_armstrong_number(115132219018763992565095597973971522401), TRUE)
-# })
-
 message("All tests passed for exercise: armstrong-numbers")

--- a/exercises/practice/armstrong-numbers/test_armstrong-numbers.R
+++ b/exercises/practice/armstrong-numbers/test_armstrong-numbers.R
@@ -1,0 +1,50 @@
+source("./armstrong-numbers.R")
+library(testthat)
+
+context("armstrong-numbers")
+
+test_that("Zero is an Armstrong number", {
+  expect_equal(is_armstrong_number(0), TRUE)
+})
+
+test_that("Single-digit numbers are Armstrong numbers", {
+  expect_equal(is_armstrong_number(5), TRUE)
+})
+
+test_that("There are no two-digit Armstrong numbers", {
+  expect_equal(is_armstrong_number(10), FALSE)
+})
+
+test_that("Three-digit number that is an Armstrong number", {
+  expect_equal(is_armstrong_number(153), TRUE)
+})
+
+test_that("Three-digit number that is not an Armstrong number", {
+  expect_equal(is_armstrong_number(100), FALSE)
+})
+
+test_that("Four-digit number that is an Armstrong number", {
+  expect_equal(is_armstrong_number(9474), TRUE)
+})
+
+test_that("Four-digit number that is not an Armstrong number", {
+  expect_equal(is_armstrong_number(9475), FALSE)
+})
+
+test_that("Seven-digit number that is an Armstrong number", {
+  expect_equal(is_armstrong_number(9926315), TRUE)
+})
+
+test_that("Seven-digit number that is not an Armstrong number", {
+  expect_equal(is_armstrong_number(9926314), FALSE)
+})
+
+# test_that("Armstrong number containing seven zeroes", {
+#   expect_equal(is_armstrong_number(186709961001538790100634132976990), TRUE)
+# })
+# 
+# test_that("The largest and last Armstrong number", {
+#   expect_equal(is_armstrong_number(115132219018763992565095597973971522401), TRUE)
+# })
+
+message("All tests passed for exercise: armstrong-numbers")


### PR DESCRIPTION
I think we probably need to omit the last 2 tests (commented out for now), which use integers of 108 and 127 bits respectively: far beyond R's int32 default. Nothing I've seen on StackOverflow is encouraging, and the suggested workarounds are probably unsuitable for Exercism testing servers.

We may need @ErikSchierboom to reopen this PR.