### PR TITLE
saddle-points: Improve instructions

### DIFF
--- a/exercises/practice/saddle-points/.docs/instructions.md
+++ b/exercises/practice/saddle-points/.docs/instructions.md
@@ -5,7 +5,7 @@ Your task is to find the potential trees where you could build your tree house.
 The data company provides the data as grids that show the heights of the trees.
 The rows of the grid represent the east-west direction, and the columns represent the north-south direction.
 
-An acceptable tree will be the the largest in its row, while being the smallest in its column.
+An acceptable tree will be the largest in its row, while being the smallest in its column.
 
 A grid might not have any good trees at all.
 Or it might have one, or even several.

--- a/exercises/practice/saddle-points/.docs/instructions.md
+++ b/exercises/practice/saddle-points/.docs/instructions.md
@@ -12,11 +12,13 @@ Or it might have one, or even several.
 
 Here is a grid that has exactly one candidate tree.
 
-    1  2  3  4
-  |-----------
-1 | 9  8  7  8
-2 | 5  3  2  4  <--- potential tree house at row 2, column 1, for tree with height 5
-3 | 6  6  7  1
+|       | 1 | 2 | 3 | 4 |
+|-------|---|---|---|---|
+| **1** | 9 | 8 | 7 | 8 |
+| **2** | 5 | 3 | 2 | 4 |
+| **3** | 6 | 6 | 7 | 1 |
+
+_Potential tree house at row 2, column 1, for tree with height 5._
 
 - Row 2 has values 5, 3, and 1. The largest value is 5.
 - Column 1 has values 9, 5, and 6. The smallest value is 5.

--- a/exercises/practice/saddle-points/.docs/instructions.md
+++ b/exercises/practice/saddle-points/.docs/instructions.md
@@ -20,7 +20,7 @@ Here is a grid that has exactly one candidate tree.
 
 _Potential tree house at row 2, column 1, for tree with height 5._
 
-- Row 2 has values 5, 3, and 1. The largest value is 5.
+- Row 2 has values 5, 3, 2, and 4. The largest value is 5.
 - Column 1 has values 9, 5, and 6. The smallest value is 5.
 
 So the point at `[2, 1]` (row: 2, column: 1) is a great spot for a tree house.


### PR DESCRIPTION
Context
======

Reading https://exercism.org/tracks/r/exercises/saddle-points and https://github.com/exercism/r/blob/6057f36/exercises/practice/saddle-points/.docs/instructions.md
is currently hard. While I was creating this pull request, I spotted a factual error in some tracks.

Change
======

- Format table using Markdown
- Fix wording
- Fix factual error

Considerations
============

At the time of writing the following tracks have similar formatting issues.

- [c](https://github.com/exercism/c/blob/966d0e7/exercises/practice/saddle-points/.docs/instructions.md)[^1]
- [elixir](https://github.com/exercism/elixir/blob/3194900/exercises/practice/saddle-points/.docs/instructions.md)
- [fsharp](https://github.com/exercism/fsharp/blob/1449281/exercises/practice/saddle-points/.docs/instructions.md)[^1]
- [python](https://github.com/exercism/python/blob/c64b14e/exercises/practice/saddle-points/.docs/instructions.md)[^1]
- [rexx](https://github.com/exercism/rexx/blob/360bc7b/exercises/practice/saddle-points/.docs/instructions.md)[^1]

The following use code blocks for formatting, which may or may not be preferable.

- [csharp](https://github.com/exercism/csharp/blob/5f737b4/exercises/practice/saddle-points/.docs/instructions.md)
- [javascript](https://github.com/exercism/javascript/blob/2056d15/exercises/practice/saddle-points/.docs/instructions.md)
- [julia](https://github.com/exercism/julia/blob/704ed41/exercises/practice/saddle-points/.docs/instructions.md)[^1]
- [problem-specifications](https://github.com/exercism/problem-specifications/blob/957e373/exercises/saddle-points/instructions.md)[^1]
- [ruby](https://github.com/exercism/ruby/blob/8a968bd/exercises/practice/saddle-points/.docs/instructions.md)

Let me know if you'd like me to make similar changes to those repositories.

[^1]: Also has the ["5, 3, and 1" issue](https://github.com/exercism/problem-specifications/pull/2272/files).