### PR TITLE
test(anagram): clean up redundant tests

### DIFF
--- a/exercises/practice/anagram/test_anagram.R
+++ b/exercises/practice/anagram/test_anagram.R
@@ -10,34 +10,6 @@ test_that("no matches", {
                c())
 })
 
-test_that("detects simple anagram", {
-  subject <- "ant"
-  candidates <- c("tan", "stand", "at")
-  expect_equal(anagram(subject, candidates),
-               c("tan"))
-})
-
-test_that("does not detect false positives", {
-  subject <- "galea"
-  candidates <- c("eagle")
-  expect_equal(anagram(subject, candidates),
-               c())
-})
-
-test_that("detects multiple anagrams", {
-  subject <- "master"
-  candidates <- c("stream", "pigeon", "maters")
-  expect_equal(anagram(subject, candidates),
-               c("stream", "maters"))
-})
-
-test_that("does not detect anagram subsets", {
-  subject <- "good"
-  candidates <- c("dog", "goody")
-  expect_equal(anagram(subject, candidates),
-               c())
-})
-
 test_that("detects anagram", {
   subject <- "listen"
   candidates <- c("enlists", "google", "inlets", "banana")
@@ -51,6 +23,20 @@ test_that("detects multiple anagrams", {
     c("gallery", "ballerina", "regally", "clergy", "largely", "leading")
   expect_equal(anagram(subject, candidates),
                c("gallery", "regally", "largely"))
+})
+
+test_that("character overlap is disregarded", {
+  subject <- "galea"
+  candidates <- c("eagle")
+  expect_equal(anagram(subject, candidates),
+               c())
+})
+
+test_that("does not detect anagram subsets", {
+  subject <- "good"
+  candidates <- c("dog", "goody")
+  expect_equal(anagram(subject, candidates),
+               c())
 })
 
 test_that("does not detect indentical words", {
@@ -67,20 +53,6 @@ test_that("does not detect non-anagrams with identical checksum", {
                c())
 })
 
-test_that("detects anagrams case-insensitively", {
-  subject <- "Orchestra"
-  candidates <- c("cashregister", "Carthorse", "radishes")
-  expect_equal(anagram(subject, candidates),
-               c("Carthorse"))
-})
-
-test_that("detects anagrams using case-insensitive subject", {
-  subject <- "Orchestra"
-  candidates <- c("cashregister", "carthorse", "radishes")
-  expect_equal(anagram(subject, candidates),
-               c("carthorse"))
-})
-
 test_that("detects anagrams using case-insensitve possible matches", {
   subject <- "orchestra"
   candidates <- c("cashregister", "Carthorse", "radishes")
@@ -95,7 +67,7 @@ test_that("does not detect a word as its own anagram", {
                c())
 })
 
-test_that("does not detect a anagram if the original word is repeated", {
+test_that("does not detect an anagram if the original word is repeated", {
   subject <- "go"
   candidates <- c("go Go GO")
   expect_equal(anagram(subject, candidates),
@@ -105,27 +77,6 @@ test_that("does not detect a anagram if the original word is repeated", {
 test_that("anagrams must use all letters exactly once", {
   subject <- "tapper"
   candidates <- c("patter")
-  expect_equal(anagram(subject, candidates),
-               c())
-})
-
-test_that("eliminates anagrams with the same checksum", {
-  subject <- "mass"
-  candidates <- c("last")
-  expect_equal(anagram(subject, candidates),
-               c())
-})
-
-test_that("capital word is not own anagram", {
-  subject <- "BANANA"
-  candidates <- c("Banana")
-  expect_equal(anagram(subject, candidates),
-               c())
-})
-
-test_that("anagrams must use all letters exactly once", {
-  subject <- "patter"
-  candidates <- c("tapper")
   expect_equal(anagram(subject, candidates),
                c())
 })


### PR DESCRIPTION
I tried to open this a few months ago during a hiatus. Reopening again 🤞🏽 https://github.com/exercism/r/pull/233

Going through this exercise I notice a fair bit of redundant testing. They loose value when duplicated and make it harder to establish the expected result.

Removed multiple tests for "detects multiple anagrams"
Removed multiple tests for "anagrams must use all letters exactly once"
Removed multiple test for "case insensitive checking"
Clarified test descriptions