### PR TITLE
enable concept exercises in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "slug": "r",
   "active": true,
   "status": {
-    "concept_exercises": false,
+    "concept_exercises": true,
     "test_runner": true,
     "representer": false,
     "analyzer": false


### PR DESCRIPTION
If I understand it correctly, we need to change `config.json` to tell the website there is a syllabus tab. So long as all the exercises are still `wip` this will only be visible to maintainers. Am I right about this?