### PR TITLE
Update test_crypto-square.R

### DIFF
--- a/exercises/practice/crypto-square/test_crypto-square.R
+++ b/exercises/practice/crypto-square/test_crypto-square.R
@@ -36,7 +36,7 @@ test_that("54 character plaintext results in an 8x7 rectangle", {
       "groundgo",
       "dwouldha",
       "vegivenu",
-      "sroots"))
+      "sroots  "))
 })
 
 test_that("empty plaintext results in an empty encode", {


### PR DESCRIPTION
In the [Crypto Square exercise description](https://exercism.org/tracks/r/exercises/crypto-square) the example given shows the last row of the rectangle padded with two spaces, but the expected result in the unit tests is missing those two spaces. I've amended the test with those spaces.