### PR TITLE
[Roman Numerals] add practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -601,6 +601,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "roman-numerals",
+        "name": "Roman Numerals",
+        "uuid": "366d83ae-a069-457e-ace9-f79417ed311f",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
       }
     ]
   },

--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -1,0 +1,41 @@
+# Instructions
+
+Write a function to convert from normal numbers to Roman Numerals.
+
+The Romans were a clever bunch.
+They conquered most of Europe and ruled it for hundreds of years.
+They invented concrete and straight roads and even bikinis.
+One thing they never discovered though was the number zero.
+This made writing and dating extensive histories of their exploits slightly more challenging, but the system of numbers they came up with is still in use today.
+For example the BBC uses Roman numerals to date their programs.
+
+The Romans wrote numbers using letters - I, V, X, L, C, D, M.
+(notice these letters have lots of straight lines and are hence easy to hack into stone tablets).
+
+```text
+ 1  => I
+10  => X
+ 7  => VII
+```
+
+The maximum number supported by this notation is 3,999.
+(The Romans themselves didn't tend to go any higher)
+
+Wikipedia says: Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any digit with a value of zero.
+
+To see this in practice, consider the example of 1990.
+
+In Roman numerals 1990 is MCMXC:
+
+1000=M
+900=CM
+90=XC
+
+2008 is written as MMVIII:
+
+2000=MM
+8=VIII
+
+Learn more about [Roman numerals on Wikipedia][roman-numerals].
+
+[roman-numerals]: https://wiki.imperivm-romanvm.com/wiki/Roman_Numerals

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,0 +1,20 @@
+{
+  "authors": [
+    "colinleach",
+    "jonmcalder"
+  ],
+  "files": {
+    "solution": [
+      "roman-numerals.R"
+    ],
+    "test": [
+      "test_roman-numerals.R"
+    ],
+    "example": [
+      ".meta/example.R"
+    ]
+  },
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
+  "source": "The Roman Numeral Kata",
+  "source_url": "https://codingdojo.org/kata/RomanNumerals/"
+}

--- a/exercises/practice/roman-numerals/.meta/example.R
+++ b/exercises/practice/roman-numerals/.meta/example.R
@@ -1,0 +1,18 @@
+library(tibble)
+
+roman <- function(arabic) {
+  nums  <-   c(1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1)
+  romans  <-  c("M", "CM", "D", "CD", "C", "XC",
+                "L", "XL", "X", "IX", "V", "IV", "I")
+  lookup <- tibble(nums, romans)
+  result <-  c()
+
+  for (i in seq_len(nrow(lookup))) {
+    num <- lookup[i, "nums"][[1]]
+    while (num <= arabic) {
+      result <- append(result, lookup[i, "romans"][[1]])
+      arabic <- arabic - num
+    }
+  }
+  paste(result, sep = "", collapse = "")
+}

--- a/exercises/practice/roman-numerals/.meta/example.R
+++ b/exercises/practice/roman-numerals/.meta/example.R
@@ -1,16 +1,13 @@
-library(tibble)
-
 roman <- function(arabic) {
-  nums  <-   c(1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1)
-  romans  <-  c("M", "CM", "D", "CD", "C", "XC",
-                "L", "XL", "X", "IX", "V", "IV", "I")
-  lookup <- tibble(nums, romans)
-  result <-  c()
-
-  for (i in seq_len(nrow(lookup))) {
-    num <- lookup[i, "nums"][[1]]
+  nums  <- c(1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1)
+  romans  <- c("M", "CM", "D", "CD", "C", "XC",
+               "L", "XL", "X", "IX", "V", "IV", "I")
+  result <- c()
+  
+  for (i in 1:length(nums)) {
+    num <- nums[i]
     while (num <= arabic) {
-      result <- append(result, lookup[i, "romans"][[1]])
+      result <- append(result, romans[i])
       arabic <- arabic - num
     }
   }

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,0 +1,88 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
+description = "1 is I"
+
+[f088f064-2d35-4476-9a41-f576da3f7b03]
+description = "2 is II"
+
+[b374a79c-3bea-43e6-8db8-1286f79c7106]
+description = "3 is III"
+
+[05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
+description = "4 is IV"
+
+[57c0f9ad-5024-46ab-975d-de18c430b290]
+description = "5 is V"
+
+[20a2b47f-e57f-4797-a541-0b3825d7f249]
+description = "6 is VI"
+
+[ff3fb08c-4917-4aab-9f4e-d663491d083d]
+description = "9 is IX"
+
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
+
+[2bda64ca-7d28-4c56-b08d-16ce65716cf6]
+description = "27 is XXVII"
+
+[a1f812ef-84da-4e02-b4f0-89c907d0962c]
+description = "48 is XLVIII"
+
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is XLIX"
+
+[d5b283d4-455d-4e68-aacf-add6c4b51915]
+description = "59 is LIX"
+
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
+
+[46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
+description = "93 is XCIII"
+
+[30494be1-9afb-4f84-9d71-db9df18b55e3]
+description = "141 is CXLI"
+
+[267f0207-3c55-459a-b81d-67cec7a46ed9]
+description = "163 is CLXIII"
+
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
+
+[cdb06885-4485-4d71-8bfb-c9d0f496b404]
+description = "402 is CDII"
+
+[6b71841d-13b2-46b4-ba97-dec28133ea80]
+description = "575 is DLXXV"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
+
+[432de891-7fd6-4748-a7f6-156082eeca2f]
+description = "911 is CMXI"
+
+[e6de6d24-f668-41c0-88d7-889c0254d173]
+description = "1024 is MXXIV"
+
+[efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
+description = "1666 is MDCLXVI"
+
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is MMM"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/roman-numerals.R
+++ b/exercises/practice/roman-numerals/roman-numerals.R
@@ -1,0 +1,3 @@
+roman <- function(arabic) {
+
+}

--- a/exercises/practice/roman-numerals/test_roman-numerals.R
+++ b/exercises/practice/roman-numerals/test_roman-numerals.R
@@ -1,0 +1,107 @@
+source("./roman-numerals.R")
+library(testthat)
+
+test_that("1 is I", {
+  expect_equal(roman(1), "I")
+})
+
+test_that("2 is II", {
+  expect_equal(roman(2), "II")
+})
+
+test_that("3 is III", {
+  expect_equal(roman(3), "III")
+})
+
+test_that("4 is IV", {
+  expect_equal(roman(4), "IV")
+})
+
+test_that("5 is V", {
+  expect_equal(roman(5), "V")
+})
+
+test_that("6 is VI", {
+  expect_equal(roman(6), "VI")
+})
+
+test_that("9 is IX", {
+  expect_equal(roman(9), "IX")
+})
+
+test_that("16 is XVI", {
+  expect_equal(roman(16), "XVI")
+})
+
+test_that("27 is XXVII", {
+  expect_equal(roman(27), "XXVII")
+})
+
+test_that("48 is XLVIII", {
+  expect_equal(roman(48), "XLVIII")
+})
+
+test_that("49 is XLIX", {
+  expect_equal(roman(49), "XLIX")
+})
+
+test_that("59 is LIX", {
+  expect_equal(roman(59), "LIX")
+})
+
+test_that("66 is LXVI", {
+  expect_equal(roman(66), "LXVI")
+})
+
+test_that("93 is XCIII", {
+  expect_equal(roman(93), "XCIII")
+})
+
+test_that("141 is CXLI", {
+  expect_equal(roman(141), "CXLI")
+})
+
+test_that("163 is CLXIII", {
+  expect_equal(roman(163), "CLXIII")
+})
+
+test_that("166 is CLXVI", {
+  expect_equal(roman(166), "CLXVI")
+})
+
+test_that("402 is CDII", {
+  expect_equal(roman(402), "CDII")
+})
+
+test_that("575 is DLXXV", {
+  expect_equal(roman(575), "DLXXV")
+})
+
+test_that("666 is DCLXVI", {
+  expect_equal(roman(666), "DCLXVI")
+})
+
+test_that("911 is CMXI", {
+  expect_equal(roman(911), "CMXI")
+})
+
+test_that("1024 is MXXIV", {
+  expect_equal(roman(1024), "MXXIV")
+})
+
+test_that("1666 is MDCLXVI", {
+  expect_equal(roman(1666), "MDCLXVI")
+})
+
+test_that("3000 is MMM", {
+  expect_equal(roman(3000), "MMM")
+})
+
+test_that("3001 is MMMI", {
+  expect_equal(roman(3001), "MMMI")
+})
+
+test_that("3999 is MMMCMXCIX", {
+  expect_equal(roman(3999), "MMMCMXCIX")
+})
+


### PR DESCRIPTION
The performance stuff for `reverse-string` is going badly, so I did this in the interim. It's for week [02-06]. Only the exercise, no Deep Dive stuff.

It works, but the example implementation may not be the most idiomatic R. A `while` loop inside a `for` loop is standard across most languages (except the ones relying heavily on pattern matching), but I'll be very happy to be shown that I'm missing something R-specific.

Feel free to replace with something better if you wish: we can use all the implementations for approaches later. It certainly isn't vectorized, but I couldn't see how to make that work within the function.