### PR TITLE
[Protein Translation] add new practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -601,6 +601,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "protein-translation",
+        "name": "Protein Translation",
+        "uuid": "dc8bb817-1c79-476a-a666-bcad9455c66a",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       }
     ]
   },

--- a/exercises/practice/protein-translation/.docs/instructions.md
+++ b/exercises/practice/protein-translation/.docs/instructions.md
@@ -1,0 +1,45 @@
+# Instructions
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a polypeptide with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
+If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting Amino Acids needed for the exercise.
+
+| Codon              | Protein       |
+| :----------------- | :------------ |
+| AUG                | Methionine    |
+| UUU, UUC           | Phenylalanine |
+| UUA, UUG           | Leucine       |
+| UCU, UCC, UCA, UCG | Serine        |
+| UAU, UAC           | Tyrosine      |
+| UGU, UGC           | Cysteine      |
+| UGG                | Tryptophan    |
+| UAA, UAG, UGA      | STOP          |
+
+Learn more about [protein translation on Wikipedia][protein-translation].
+
+[protein-translation]: https://en.wikipedia.org/wiki/Translation_(biology)

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "colinleach",
+    "jonmcalder"
+  ],
+  "files": {
+    "solution": [
+      "protein-translation.R"
+    ],
+    "test": [
+      "test_protein-translation.R"
+    ],
+    "example": [
+      ".meta/example.R"
+    ]
+  },
+  "blurb": "Translate RNA sequences into proteins.",
+  "source": "Tyler Long"
+}

--- a/exercises/practice/protein-translation/.meta/example.R
+++ b/exercises/practice/protein-translation/.meta/example.R
@@ -1,0 +1,31 @@
+proteins <- function(bases) {
+  if (nchar(bases) == 0) return(NULL)
+  
+  codons <- strsplit(bases, "(?<=.{3})", perl=TRUE)[[1]]
+  
+  translation <- list(
+    AUG = "Methionine", UUU = "Phenylalanine", UUC = "Phenylalanine", 
+    UUA = "Leucine", UUG = "Leucine", UCU = "Serine", UCC = "Serine",  
+    UCA = "Serine", UCG = "Serine", UAU = "Tyrosine", UAC = "Tyrosine", 
+    UGU = "Cysteine", UGC = "Cysteine", UGG = "Tryptophan", UAA = "STOP", 
+    UAG = "STOP", UGA = "STOP")
+  
+  output <- c()
+  
+  for (codon in codons) {
+    # All valid codons must be 3 characters
+    if (nchar(codon) != 3) stop("Invalid codon")
+    
+    amino_acid <- translation[[codon]]
+    
+    # Not all 3-letter sequences are valid codons
+    if (is.null(amino_acid)) stop("Invalid codon")
+    
+    # Obey a STOP codon and return what we have so far
+    if (amino_acid == "STOP") break
+    
+    output <- append(output, amino_acid)
+  }
+  
+  output
+}

--- a/exercises/practice/protein-translation/.meta/example.R
+++ b/exercises/practice/protein-translation/.meta/example.R
@@ -1,31 +1,31 @@
 proteins <- function(bases) {
   if (nchar(bases) == 0) return(NULL)
-  
-  codons <- strsplit(bases, "(?<=.{3})", perl=TRUE)[[1]]
-  
+
+  codons <- strsplit(bases, "(?<=.{3})", perl = TRUE)[[1]]
+
   translation <- list(
-    AUG = "Methionine", UUU = "Phenylalanine", UUC = "Phenylalanine", 
-    UUA = "Leucine", UUG = "Leucine", UCU = "Serine", UCC = "Serine",  
-    UCA = "Serine", UCG = "Serine", UAU = "Tyrosine", UAC = "Tyrosine", 
-    UGU = "Cysteine", UGC = "Cysteine", UGG = "Tryptophan", UAA = "STOP", 
+    AUG = "Methionine", UUU = "Phenylalanine", UUC = "Phenylalanine",
+    UUA = "Leucine", UUG = "Leucine", UCU = "Serine", UCC = "Serine",
+    UCA = "Serine", UCG = "Serine", UAU = "Tyrosine", UAC = "Tyrosine",
+    UGU = "Cysteine", UGC = "Cysteine", UGG = "Tryptophan", UAA = "STOP",
     UAG = "STOP", UGA = "STOP")
-  
+
   output <- c()
-  
+
   for (codon in codons) {
     # All valid codons must be 3 characters
     if (nchar(codon) != 3) stop("Invalid codon")
-    
+
     amino_acid <- translation[[codon]]
-    
+
     # Not all 3-letter sequences are valid codons
     if (is.null(amino_acid)) stop("Invalid codon")
-    
+
     # Obey a STOP codon and return what we have so far
     if (amino_acid == "STOP") break
-    
+
     output <- append(output, amino_acid)
   }
-  
+
   output
 }

--- a/exercises/practice/protein-translation/.meta/example.R
+++ b/exercises/practice/protein-translation/.meta/example.R
@@ -1,4 +1,4 @@
-proteins <- function(bases) {
+translate <- function(bases) {
   if (nchar(bases) == 0) return(NULL)
 
   codons <- strsplit(bases, "(?<=.{3})", perl = TRUE)[[1]]

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -1,0 +1,100 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98]
+description = "Empty RNA sequence results in no proteins"
+
+[96d3d44f-34a2-4db4-84cd-fff523e069be]
+description = "Methionine RNA sequence"
+
+[1b4c56d8-d69f-44eb-be0e-7b17546143d9]
+description = "Phenylalanine RNA sequence 1"
+
+[81b53646-bd57-4732-b2cb-6b1880e36d11]
+description = "Phenylalanine RNA sequence 2"
+
+[42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4]
+description = "Leucine RNA sequence 1"
+
+[ac5edadd-08ed-40a3-b2b9-d82bb50424c4]
+description = "Leucine RNA sequence 2"
+
+[8bc36e22-f984-44c3-9f6b-ee5d4e73f120]
+description = "Serine RNA sequence 1"
+
+[5c3fa5da-4268-44e5-9f4b-f016ccf90131]
+description = "Serine RNA sequence 2"
+
+[00579891-b594-42b4-96dc-7ff8bf519606]
+description = "Serine RNA sequence 3"
+
+[08c61c3b-fa34-4950-8c4a-133945570ef6]
+description = "Serine RNA sequence 4"
+
+[54e1e7d8-63c0-456d-91d2-062c72f8eef5]
+description = "Tyrosine RNA sequence 1"
+
+[47bcfba2-9d72-46ad-bbce-22f7666b7eb1]
+description = "Tyrosine RNA sequence 2"
+
+[3a691829-fe72-43a7-8c8e-1bd083163f72]
+description = "Cysteine RNA sequence 1"
+
+[1b6f8a26-ca2f-43b8-8262-3ee446021767]
+description = "Cysteine RNA sequence 2"
+
+[1e91c1eb-02c0-48a0-9e35-168ad0cb5f39]
+description = "Tryptophan RNA sequence"
+
+[e547af0b-aeab-49c7-9f13-801773a73557]
+description = "STOP codon RNA sequence 1"
+
+[67640947-ff02-4f23-a2ef-816f8a2ba72e]
+description = "STOP codon RNA sequence 2"
+
+[9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
+description = "STOP codon RNA sequence 3"
+
+[f4d9d8ee-00a8-47bf-a1e3-1641d4428e54]
+description = "Sequence of two protein codons translates into proteins"
+
+[dd22eef3-b4f1-4ad6-bb0b-27093c090a9d]
+description = "Sequence of two different protein codons translates into proteins"
+
+[d0f295df-fb70-425c-946c-ec2ec185388e]
+description = "Translate RNA strand into correct protein list"
+
+[e30e8505-97ec-4e5f-a73e-5726a1faa1f4]
+description = "Translation stops if STOP codon at beginning of sequence"
+
+[5358a20b-6f4c-4893-bce4-f929001710f3]
+description = "Translation stops if STOP codon at end of two-codon sequence"
+
+[ba16703a-1a55-482f-bb07-b21eef5093a3]
+description = "Translation stops if STOP codon at end of three-codon sequence"
+
+[4089bb5a-d5b4-4e71-b79e-b8d1f14a2911]
+description = "Translation stops if STOP codon in middle of three-codon sequence"
+
+[2c2a2a60-401f-4a80-b977-e0715b23b93d]
+description = "Translation stops if STOP codon in middle of six-codon sequence"
+
+[1e75ea2a-f907-4994-ae5c-118632a1cb0f]
+description = "Non-existing codon can't translate"
+
+[9eac93f3-627a-4c90-8653-6d0a0595bc6f]
+description = "Unknown amino acids, not part of a codon, can't translate"
+
+[9d73899f-e68e-4291-b1e2-7bf87c00f024]
+description = "Incomplete RNA sequence can't translate"
+
+[43945cf7-9968-402d-ab9f-b8a28750b050]
+description = "Incomplete RNA sequence can translate if valid until a STOP codon"

--- a/exercises/practice/protein-translation/protein-translation.R
+++ b/exercises/practice/protein-translation/protein-translation.R
@@ -1,3 +1,3 @@
-proteins <- function(bases) {
+translate <- function(bases) {
 
 }

--- a/exercises/practice/protein-translation/protein-translation.R
+++ b/exercises/practice/protein-translation/protein-translation.R
@@ -1,0 +1,3 @@
+proteins <- function(bases) {
+
+}

--- a/exercises/practice/protein-translation/test_protein-translation.R
+++ b/exercises/practice/protein-translation/test_protein-translation.R
@@ -1,0 +1,125 @@
+source('./protein-translation.R')
+library(testthat)
+
+# test_that("Empty RNA sequence results in no proteins", {
+#   expect_equal(proteins(""), NULL)
+# })
+
+test_that("Methionine RNA sequence", {
+  expect_equal(proteins("AUG"), 'Methionine')
+})
+
+test_that("Phenylalanine RNA sequence 1", {
+  expect_equal(proteins("UUU"), 'Phenylalanine')
+})
+
+test_that("Phenylalanine RNA sequence 2", {
+  expect_equal(proteins("UUC"), 'Phenylalanine')
+})
+
+test_that("Leucine RNA sequence 1", {
+  expect_equal(proteins("UUA"), 'Leucine')
+})
+
+test_that("Leucine RNA sequence 2", {
+  expect_equal(proteins("UUG"), 'Leucine')
+})
+
+test_that("Serine RNA sequence 1", {
+  expect_equal(proteins("UCU"), 'Serine')
+})
+
+test_that("Serine RNA sequence 2", {
+  expect_equal(proteins("UCC"), 'Serine')
+})
+
+test_that("Serine RNA sequence 3", {
+  expect_equal(proteins("UCA"), 'Serine')
+})
+
+test_that("Serine RNA sequence 4", {
+  expect_equal(proteins("UCG"), 'Serine')
+})
+
+test_that("Tyrosine RNA sequence 1", {
+  expect_equal(proteins("UAU"), 'Tyrosine')
+})
+
+test_that("Tyrosine RNA sequence 2", {
+  expect_equal(proteins("UAC"), 'Tyrosine')
+})
+
+test_that("Cysteine RNA sequence 1", {
+  expect_equal(proteins("UGU"), 'Cysteine')
+})
+
+test_that("Cysteine RNA sequence 2", {
+  expect_equal(proteins("UGC"), 'Cysteine')
+})
+
+test_that("Tryptophan RNA sequence", {
+  expect_equal(proteins("UGG"), 'Tryptophan')
+})
+
+test_that("STOP codon RNA sequence 1", {
+  expect_equal(proteins("UAA"), c())
+})
+
+test_that("STOP codon RNA sequence 2", {
+  expect_equal(proteins("UAG"), c())
+})
+
+test_that("STOP codon RNA sequence 3", {
+  expect_equal(proteins("UGA"), c())
+})
+
+test_that("Sequence of two protein codons translates into proteins", {
+  expect_equal(proteins("UUUUUU"), c('Phenylalanine', 'Phenylalanine'))
+})
+
+test_that("Sequence of two different protein codons translates into proteins", {
+  expect_equal(proteins("UUAUUG"), c('Leucine', 'Leucine'))
+})
+
+test_that("Translate RNA strand into correct protein list", {
+  expect_equal(proteins("AUGUUUUGG"), 
+               c('Methionine', 'Phenylalanine', 'Tryptophan'))
+})
+
+test_that("Translation stops if STOP codon at beginning of sequence", {
+  expect_equal(proteins("UAGUGG"), c())
+})
+
+test_that("Translation stops if STOP codon at end of two-codon sequence", {
+  expect_equal(proteins("UGGUAG"), c('Tryptophan'))
+})
+
+test_that("Translation stops if STOP codon at end of three-codon sequence", {
+  expect_equal(proteins("AUGUUUUAA"), c('Methionine', 'Phenylalanine'))
+})
+
+test_that("Translation stops if STOP codon in middle of three-codon sequence", {
+  expect_equal(proteins("UGGUAGUGG"), c('Tryptophan'))
+})
+
+test_that("Translation stops if STOP codon in middle of six-codon sequence", {
+  expect_equal(proteins("UGGUGUUAUUAAUGGUUU"), 
+               c('Tryptophan', 'Cysteine', 'Tyrosine'))
+})
+
+test_that("Non-existing codon can't translate", {
+  expect_error(proteins("AAA"))
+})
+
+test_that("Unknown amino acids, not part of a codon, can't translate", {
+  expect_error(proteins("XYZ"))
+})
+
+test_that("Incomplete RNA sequence can't translate", {
+  expect_error(proteins("AUGU"))
+})
+
+test_that("Incomplete RNA sequence can translate if valid until a STOP codon", {
+  expect_equal(proteins("UUCUUCUAAUGGU"), c('Phenylalanine', 'Phenylalanine'))
+})
+

--- a/exercises/practice/protein-translation/test_protein-translation.R
+++ b/exercises/practice/protein-translation/test_protein-translation.R
@@ -1,9 +1,9 @@
 source('./protein-translation.R')
 library(testthat)
 
-# test_that("Empty RNA sequence results in no proteins", {
-#   expect_equal(proteins(""), NULL)
-# })
+test_that("Empty RNA sequence results in no proteins", {
+  expect_equal(proteins(""), NULL)
+})
 
 test_that("Methionine RNA sequence", {
   expect_equal(proteins("AUG"), 'Methionine')

--- a/exercises/practice/protein-translation/test_protein-translation.R
+++ b/exercises/practice/protein-translation/test_protein-translation.R
@@ -2,124 +2,124 @@ source('./protein-translation.R')
 library(testthat)
 
 test_that("Empty RNA sequence results in no proteins", {
-  expect_equal(proteins(""), NULL)
+  expect_equal(translate(""), NULL)
 })
 
 test_that("Methionine RNA sequence", {
-  expect_equal(proteins("AUG"), 'Methionine')
+  expect_equal(translate("AUG"), 'Methionine')
 })
 
 test_that("Phenylalanine RNA sequence 1", {
-  expect_equal(proteins("UUU"), 'Phenylalanine')
+  expect_equal(translate("UUU"), 'Phenylalanine')
 })
 
 test_that("Phenylalanine RNA sequence 2", {
-  expect_equal(proteins("UUC"), 'Phenylalanine')
+  expect_equal(translate("UUC"), 'Phenylalanine')
 })
 
 test_that("Leucine RNA sequence 1", {
-  expect_equal(proteins("UUA"), 'Leucine')
+  expect_equal(translate("UUA"), 'Leucine')
 })
 
 test_that("Leucine RNA sequence 2", {
-  expect_equal(proteins("UUG"), 'Leucine')
+  expect_equal(translate("UUG"), 'Leucine')
 })
 
 test_that("Serine RNA sequence 1", {
-  expect_equal(proteins("UCU"), 'Serine')
+  expect_equal(translate("UCU"), 'Serine')
 })
 
 test_that("Serine RNA sequence 2", {
-  expect_equal(proteins("UCC"), 'Serine')
+  expect_equal(translate("UCC"), 'Serine')
 })
 
 test_that("Serine RNA sequence 3", {
-  expect_equal(proteins("UCA"), 'Serine')
+  expect_equal(translate("UCA"), 'Serine')
 })
 
 test_that("Serine RNA sequence 4", {
-  expect_equal(proteins("UCG"), 'Serine')
+  expect_equal(translate("UCG"), 'Serine')
 })
 
 test_that("Tyrosine RNA sequence 1", {
-  expect_equal(proteins("UAU"), 'Tyrosine')
+  expect_equal(translate("UAU"), 'Tyrosine')
 })
 
 test_that("Tyrosine RNA sequence 2", {
-  expect_equal(proteins("UAC"), 'Tyrosine')
+  expect_equal(translate("UAC"), 'Tyrosine')
 })
 
 test_that("Cysteine RNA sequence 1", {
-  expect_equal(proteins("UGU"), 'Cysteine')
+  expect_equal(translate("UGU"), 'Cysteine')
 })
 
 test_that("Cysteine RNA sequence 2", {
-  expect_equal(proteins("UGC"), 'Cysteine')
+  expect_equal(translate("UGC"), 'Cysteine')
 })
 
 test_that("Tryptophan RNA sequence", {
-  expect_equal(proteins("UGG"), 'Tryptophan')
+  expect_equal(translate("UGG"), 'Tryptophan')
 })
 
 test_that("STOP codon RNA sequence 1", {
-  expect_equal(proteins("UAA"), c())
+  expect_equal(translate("UAA"), c())
 })
 
 test_that("STOP codon RNA sequence 2", {
-  expect_equal(proteins("UAG"), c())
+  expect_equal(translate("UAG"), c())
 })
 
 test_that("STOP codon RNA sequence 3", {
-  expect_equal(proteins("UGA"), c())
+  expect_equal(translate("UGA"), c())
 })
 
 test_that("Sequence of two protein codons translates into proteins", {
-  expect_equal(proteins("UUUUUU"), c('Phenylalanine', 'Phenylalanine'))
+  expect_equal(translate("UUUUUU"), c('Phenylalanine', 'Phenylalanine'))
 })
 
 test_that("Sequence of two different protein codons translates into proteins", {
-  expect_equal(proteins("UUAUUG"), c('Leucine', 'Leucine'))
+  expect_equal(translate("UUAUUG"), c('Leucine', 'Leucine'))
 })
 
 test_that("Translate RNA strand into correct protein list", {
-  expect_equal(proteins("AUGUUUUGG"), 
+  expect_equal(translate("AUGUUUUGG"), 
                c('Methionine', 'Phenylalanine', 'Tryptophan'))
 })
 
 test_that("Translation stops if STOP codon at beginning of sequence", {
-  expect_equal(proteins("UAGUGG"), c())
+  expect_equal(translate("UAGUGG"), c())
 })
 
 test_that("Translation stops if STOP codon at end of two-codon sequence", {
-  expect_equal(proteins("UGGUAG"), c('Tryptophan'))
+  expect_equal(translate("UGGUAG"), c('Tryptophan'))
 })
 
 test_that("Translation stops if STOP codon at end of three-codon sequence", {
-  expect_equal(proteins("AUGUUUUAA"), c('Methionine', 'Phenylalanine'))
+  expect_equal(translate("AUGUUUUAA"), c('Methionine', 'Phenylalanine'))
 })
 
 test_that("Translation stops if STOP codon in middle of three-codon sequence", {
-  expect_equal(proteins("UGGUAGUGG"), c('Tryptophan'))
+  expect_equal(translate("UGGUAGUGG"), c('Tryptophan'))
 })
 
 test_that("Translation stops if STOP codon in middle of six-codon sequence", {
-  expect_equal(proteins("UGGUGUUAUUAAUGGUUU"), 
+  expect_equal(translate("UGGUGUUAUUAAUGGUUU"), 
                c('Tryptophan', 'Cysteine', 'Tyrosine'))
 })
 
 test_that("Non-existing codon can't translate", {
-  expect_error(proteins("AAA"))
+  expect_error(translate("AAA"))
 })
 
 test_that("Unknown amino acids, not part of a codon, can't translate", {
-  expect_error(proteins("XYZ"))
+  expect_error(translate("XYZ"))
 })
 
 test_that("Incomplete RNA sequence can't translate", {
-  expect_error(proteins("AUGU"))
+  expect_error(translate("AUGU"))
 })
 
 test_that("Incomplete RNA sequence can translate if valid until a STOP codon", {
-  expect_equal(proteins("UUCUUCUAAUGGU"), c('Phenylalanine', 'Phenylalanine'))
+  expect_equal(translate("UUCUUCUAAUGGU"), c('Phenylalanine', 'Phenylalanine'))
 })
 


### PR DESCRIPTION
For week [02-13], so not _very_ urgent. Again, just the exercise with no approaches yet.

I had hoped to do something clever and vectorized with this exercise, but tripped over the endless validity-checking. This needs to be done in a specific order, so I ended up putting most things in a `for` loop. 

Maybe we could translate the whole sequence, then truncate to everything before the first "STOP" codon, then check for invalid elements? Probably still not elegant, and I've done enough molecular biology in my career to have a feel for how big real-world sequences can get - translating onward past a STOP isn't great.