### PR TITLE
Fix phone number tests

### DIFF
--- a/exercises/practice/phone-number/.meta/example.R
+++ b/exercises/practice/phone-number/.meta/example.R
@@ -1,35 +1,7 @@
 parse_phone_number <- function(number_string) {
-  
-  # If the number is less than 10 digits assume that it is bad number
-  # If the number is 10 digits assume that it is good, unless area or exchange 
-  #  code are not between 2 to 9
-  # If the number is 11 digits and the first number is 1, use the last 10 digits
-  # If the number is 11 digits and the first number is not 1, it is a bad number
-  # If the number is more than 11 digits assume that it is a bad number
- 
-  # Check for letters
-  if (grepl("[A-z]", number_string)) {
-    return (NULL)
-  }
-  
-  # Remove non-digit characters from number string
-  cleaned <- gsub("[^0-9]", "", number_string)
-  
-  if (nchar(cleaned) < 10) {
-    NULL
-  }
-  else if (nchar(cleaned) == 10 & (substr(cleaned, 1, 1) %in% c("0", "1") |
-                                   substr(cleaned, 4, 4) %in% c("0", "1"))) {
-    NULL
-  } 
-  else if (nchar(cleaned) == 10) {
-    cleaned
-  } 
-  else if (nchar(cleaned) == 11 & substr(cleaned, 1, 1) == "1") {
-    substr(cleaned, 2, 11)
-  }
-  else {
-    NULL
-  }
- 
+  str <- gsub("\\D", replacement = "", number_string)
+  if (substr(str, 1, 1) == '1') str <- substr(str, 2, nchar(str))
+  if (nchar(str) != 10) return(NULL)
+  if (strtoi(substr(str, 1, 1)) < 2 || strtoi(substr(str, 4, 4)) < 2) return(NULL)
+  str
 }

--- a/exercises/practice/phone-number/.meta/example.R
+++ b/exercises/practice/phone-number/.meta/example.R
@@ -1,7 +1,10 @@
 parse_phone_number <- function(number_string) {
   str <- gsub("\\D", replacement = "", number_string)
-  if (substr(str, 1, 1) == '1') str <- substr(str, 2, nchar(str))
-  if (nchar(str) != 10) return(NULL)
-  if (strtoi(substr(str, 1, 1)) < 2 || strtoi(substr(str, 4, 4)) < 2) return(NULL)
+  if (substr(str, 1, 1) == '1') 
+    str <- substr(str, 2, nchar(str))
+  if (nchar(str) != 10) 
+    return(NULL)
+  if (strtoi(substr(str, 1, 1)) < 2 || strtoi(substr(str, 4, 4)) < 2) 
+    return(NULL)
   str
 }

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [79666dce-e0f1-46de-95a1-563802913c35]
 description = "cleans the number"
@@ -13,6 +20,11 @@ description = "cleans numbers with multiple spaces"
 
 [598d8432-0659-4019-a78b-1c6a73691d21]
 description = "invalid when 9 digits"
+include = false
+
+[2de74156-f646-42b5-8638-0ef1d8b58bc2]
+description = "invalid when 9 digits"
+reimplements = "598d8432-0659-4019-a78b-1c6a73691d21"
 
 [57061c72-07b5-431f-9766-d97da7c4399d]
 description = "invalid when 11 digits does not start with a 1"
@@ -25,12 +37,27 @@ description = "valid when 11 digits and starting with 1 even with punctuation"
 
 [c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
 description = "invalid when more than 11 digits"
+include = false
+
+[4a1509b7-8953-4eec-981b-c483358ff531]
+description = "invalid when more than 11 digits"
+reimplements = "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad"
 
 [63f38f37-53f6-4a5f-bd86-e9b404f10a60]
 description = "invalid with letters"
+include = false
+
+[eb8a1fc0-64e5-46d3-b0c6-33184208e28a]
+description = "invalid with letters"
+reimplements = "63f38f37-53f6-4a5f-bd86-e9b404f10a60"
 
 [4bd97d90-52fd-45d3-b0db-06ab95b1244e]
 description = "invalid with punctuations"
+include = false
+
+[065f6363-8394-4759-b080-e6c8c351dd1f]
+description = "invalid with punctuations"
+reimplements = "4bd97d90-52fd-45d3-b0db-06ab95b1244e"
 
 [d77d07f8-873c-4b17-8978-5f66139bf7d7]
 description = "invalid if area code starts with 0"

--- a/exercises/practice/phone-number/test_phone-number.R
+++ b/exercises/practice/phone-number/test_phone-number.R
@@ -25,22 +25,51 @@ test_that("valid when 11 digits and starting with 1", {
   expect_equal(parse_phone_number("12234567890"), "2234567890")
 })
 
+test_that("valid when 11 digits and starting with 1 even with punctuation", {
+  expect_equal(parse_phone_number("+1 (223) 456-7890"), "2234567890")
+})
+
 test_that("invalid when more than 11 digits", {
   expect_equal(parse_phone_number("321234567890"), NULL)
 })
 
 test_that("invalid with letters", {
-  expect_equal(parse_phone_number("123-abc-7890"), NULL)
+  expect_equal(parse_phone_number("523-abc-7890"), NULL)
 })
 
 test_that("invalid with punctuations", {
-  expect_equal(parse_phone_number("123-@:!-7890"), NULL)
+  expect_equal(parse_phone_number("523-@:!-7890"), NULL)
 })
 
-test_that("invalid if area code does not start with 2-9", {
+test_that("invalid if area code starts with 0", {
+  expect_equal(parse_phone_number("(023) 456-7890"), NULL)
+})
+
+test_that("invalid if area code starts with 1", {
   expect_equal(parse_phone_number("(123) 456-7890"), NULL)
 })
 
-test_that("invalid if exchange code does not start with 2-9", {
+test_that("invalid if exchange code starts with 0", {
   expect_equal(parse_phone_number("(223) 056-7890"), NULL)
 })
+
+test_that("invalid if exchange code starts with 1", {
+  expect_equal(parse_phone_number("(223) 156-7890"), NULL)
+})
+
+test_that("invalid if area code starts with 0 on valid 11-digit number", {
+  expect_equal(parse_phone_number("1 (023) 456-7890"), NULL)
+})
+
+test_that("invalid if area code starts with 1 on valid 11-digit number", {
+  expect_equal(parse_phone_number("1 (123) 456-7890"), NULL)
+})
+
+test_that("invalid if exchange code starts with 0 on valid 11-digit number", {
+  expect_equal(parse_phone_number("1 (223) 056-7890"), NULL)
+})
+
+test_that("invalid if exchange code starts with 1 on valid 11-digit number", {
+  expect_equal(parse_phone_number("1 (223) 156-7890"), NULL)
+})
+


### PR DESCRIPTION
This PR in phone-number exercise:

- Synced via configlet tests.toml with canonical
- Deleted two non-canonical tests, added 5 missing canonical and a few reimplemented tests
- changed example.R to passing new tests.