### PR TITLE
flatten-array: fix nesting

### DIFF
--- a/exercises/practice/flatten-array/.meta/example.R
+++ b/exercises/practice/flatten-array/.meta/example.R
@@ -1,5 +1,5 @@
 flatten <- function(input) {
-  flattened = c()
+  flattened <- c()
   
   for (element in input) {
     if (is.null(element)) next

--- a/exercises/practice/flatten-array/.meta/example.R
+++ b/exercises/practice/flatten-array/.meta/example.R
@@ -1,3 +1,14 @@
 flatten <- function(input) {
-  input[!is.null(input)]
+  flattened = c()
+  
+  for (element in input) {
+    if (is.null(element)) next
+    
+    if (is.list(element))
+      flattened <- c(flattened, flatten(element))
+    else
+      flattened <- c(flattened, element)
+  }
+  
+  flattened
 }

--- a/exercises/practice/flatten-array/test_flatten-array.R
+++ b/exercises/practice/flatten-array/test_flatten-array.R
@@ -2,67 +2,67 @@ source("./flatten-array.R")
 library(testthat)
 
 test_that("empty", {
-  inputs <- c()
+  inputs <- list()
   expected <- c()
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("no nesting", {
-  inputs <- c(0, 1, 2)
+  inputs <- list(0, 1, 2)
   expected <- c(0, 1, 2)
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("flattens a nested array", {
-  inputs <- c(c(c()))
+  inputs <- list(list(list()))
   expected <- c()
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("flattens array with just integers present", {
-  inputs <- c(1, c(2, 3, 4, 5, 6, 7), 8)
+  inputs <- list(1, list(2, 3, 4, 5, 6, 7), 8)
   expected <- c(1, 2, 3, 4, 5, 6, 7, 8)
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("5 level nesting", {
-  inputs <- c(0, 2, c(c(2, 3), 8, 100, 4, c(c(c(50)))), -2)
+  inputs <- list(0, 2, list(list(2, 3), 8, 100, 4, list(list(list(50)))), -2)
   expected <- c(0, 2, 2, 3, 8, 100, 4, 50, -2)
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("6 level nesting", {
-  inputs <- c(1, c(2, c(c(3)), c(4, c(c(5))), 6, 7), 8)
+  inputs <- list(1, list(2, list(list(3)), list(4, list(list(5))), 6, 7), 8)
   expected <- c(1, 2, 3, 4, 5, 6, 7, 8)
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("null values are omitted from the final result", {
-  inputs <- c(1, 2, NULL)
+  inputs <- list(1, 2, NULL)
   expected <- c(1, 2)
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("consecutive null values at the front of the list are omitted from the final result", { # nolint
-  inputs <- c(NULL, NULL, 3)
+  inputs <- list(NULL, NULL, 3)
   expected <- c(3)
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("consecutive null values in the middle of the list are omitted from the final result", { # nolint
-  inputs <- c(1, NULL, NULL, 4)
+  inputs <- list(1, NULL, NULL, 4)
   expected <- c(1, 4)
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("6 level nest list with null values", {
-  inputs <- c(0, 2, c(c(2, 3), 8, c(c(100)), NULL, c(c(NULL))), -2)
+  inputs <- list(0, 2, list(list(2, 3), 8, list(list(100)), NULL, list(list(NULL))), -2) # nolint
   expected <- c(0, 2, 2, 3, 8, 100, -2)
   expect_equal(flatten(inputs), expected)
 })
 
 test_that("all values in nested list are null", {
-  inputs <- c(NULL, c(c(c(NULL))), NULL, NULL, c(c(NULL, NULL), NULL), NULL)
+  inputs <- list(NULL, list(list(list(NULL))), NULL, NULL, list(list(NULL, NULL), NULL), NULL) # nolint
   expected <- c()
   expect_equal(flatten(inputs), expected)
 })


### PR DESCRIPTION
I erronously used `c()` for nesting, but that won't actually create nesting. Switched to `list()` Sorry!