### PR TITLE
CI: add tidyverse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install project dependencies
         run: |
-          install.packages(c("testthat", "jsonlite", "lintr", "tidyverse", "dplyr"))
+          install.packages(c("testthat", "jsonlite", "lintr", "dplyr", "stringr", "readr", "purrr", "tibble"))
         shell: Rscript {0}
 
       - name: Run exercism/r ci (runs tests) for all exercises

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install project dependencies
         run: |
-          install.packages(c("testthat", "jsonlite", "lintr", "dplyr"))
+          install.packages(c("testthat", "jsonlite", "lintr", "tidyverse", "dplyr"))
         shell: Rscript {0}
 
       - name: Run exercism/r ci (runs tests) for all exercises


### PR DESCRIPTION
I tried adding `tidyverse` as a full package, but got alarmed when GH took 11m36s to install the dependencies (lots of C++17 compilation).

Thinking about it some more, we definitely don't need `ggplot2` (a big plotting package), and probably don't need `tidyr` or `forcats` (mainly about data cleaning). Adding `"dplyr", "stringr", "readr", "purrr", "tibble"` brought installation time down to 6m20s. I assume GH will cache the results somewhere?