### PR TITLE
Use GHA workflow to install dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,24 @@ jobs:
   ci:
     runs-on: ubuntu-22.04
 
-    strategy:
-      matrix:
-        R: ["4.3.1"]
-
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@e6be4b3706e0f39bc7a4cf4496a5f2c4cb840040
         with:
-          r-version: ${{ matrix.R }}
+          r-version: 4.3.1
 
-      - name: Install project dependencies
-        run: |
-          install.packages(c("testthat", "jsonlite", "lintr", "dplyr", "stringr", "readr", "purrr", "tibble"))
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@e6be4b3706e0f39bc7a4cf4496a5f2c4cb840040
+        with:
+          cache-version: 1
+          packages: |
+            testthat
+            jsonlite
+            dplyr
+            stringr
+            readr
+            purrr
+            tibble
 
       - name: Run exercism/r ci (runs tests) for all exercises
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,15 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@e6be4b3706e0f39bc7a4cf4496a5f2c4cb840040
         with:
           r-version: 4.3.1
-          use-public-rspm: true
 
-      - name: Install project dependencies
-        run: |
-          install.packages(c("testthat", "jsonlite", "lintr"))
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@e6be4b3706e0f39bc7a4cf4496a5f2c4cb840040
+        with:
+          cache-version: 1
+          packages: |
+            lintr
 
       - name: Run exercism/r ci pre-check (checks config, lint code) for all exercises
         run: |


### PR DESCRIPTION
@colinleach According to the docs, using [this workflow](https://github.com/r-lib/actions/tree/v2/setup-r-dependencies) _will_ cache things, which should greatly speed up our builds (after the initial run).