### PR TITLE
[Github Workflow Tooling] Update ci.yml to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Switching ubuntu version to latest LTS of 24.04.

Per private discussion on forum, instigated by [this thread](https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612/20).