### PR TITLE
Adding exercise "palindrome-products" to track "r"

### DIFF
--- a/config.json
+++ b/config.json
@@ -939,6 +939,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5
+      },
+      {
+        "slug": "palindrome-products",
+        "name": "Palindrome Products",
+        "uuid": "2776fe9f-922b-4731-804b-0901c3b514cc",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6
       }
     ]
   },

--- a/exercises/practice/palindrome-products/.docs/instructions.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.md
@@ -1,0 +1,36 @@
+# Instructions
+
+Detect palindrome products in a given range.
+
+A palindromic number is a number that remains the same when its digits are reversed.
+For example, `121` is a palindromic number but `112` is not.
+
+Given a range of numbers, find the largest and smallest palindromes which
+are products of two numbers within that range.
+
+Your solution should return the largest and smallest palindromes, along with the factors of each within the range.
+If the largest or smallest palindrome has more than one pair of factors within the range, then return all the pairs.
+
+## Example 1
+
+Given the range `[1, 9]` (both inclusive)...
+
+And given the list of all possible products within this range:
+`[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 15, 21, 24, 27, 20, 28, 32, 36, 25, 30, 35, 40, 45, 42, 48, 54, 49, 56, 63, 64, 72, 81]`
+
+The palindrome products are all single digit numbers (in this case):
+`[1, 2, 3, 4, 5, 6, 7, 8, 9]`
+
+The smallest palindrome product is `1`.
+Its factors are `(1, 1)`.
+The largest palindrome product is `9`.
+Its factors are `(1, 9)` and `(3, 3)`.
+
+## Example 2
+
+Given the range `[10, 99]` (both inclusive)...
+
+The smallest palindrome product is `121`.
+Its factors are `(11, 11)`.
+The largest palindrome product is `9009`.
+Its factors are `(91, 99)`.

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "frequenter-at-exercism"
+  ],
+  "files": {
+    "solution": [
+      "palindrome-products.R"
+    ],
+    "test": [
+      "test_palindrome-products.R"
+    ],
+    "example": [
+      ".meta/example.R"
+    ]
+  },
+  "blurb": "Detect palindrome products in a given range.",
+  "source": "Problem 4 at Project Euler",
+  "source_url": "https://projecteuler.net/problem=4"
+}

--- a/exercises/practice/palindrome-products/.meta/example.R
+++ b/exercises/practice/palindrome-products/.meta/example.R
@@ -1,0 +1,82 @@
+verso <- \(n) {
+  v <- 0
+  while (n > 0) {
+    v <- 10 * v + n %% 10
+    n <- n %/% 10
+  }
+  v
+}
+
+nlen <- \(n) ceiling(log10(n + 1))
+
+haflen <- \(n) (log10(n) + 1) %/% 2
+
+nconc <- \(m, n) m * 10 ^ nlen(n) + n
+
+succ <- \(n) {
+  if (n == 0) return(1) # kludge
+  nl <- nlen(n)
+  if (nl != nlen(n + 1)) return(n + 2)
+  hl <- haflen(n)
+  left <- n %/% 10 ^ (nl - hl)
+  leftmid <- n %/% 10 ^ hl
+  right <- n %% 10 ^ hl
+  v <- verso(left)
+  if (v > right) return(nconc(leftmid, v))
+  newleftmid <- leftmid + 1
+  newright <- verso(newleftmid %/% 10 ^ (nl - 2 * hl))
+  newleftmid * 10 ^ hl + newright
+}
+
+pred <- \(n) {
+  nl <- nlen(n)
+  if (n - 1 == 10 ^ (nl - 1)) return(n - 2)
+  hl <- haflen(n)
+  left <- n %/% 10 ^ (nl - hl)
+  leftmid <- n %/% 10 ^ hl
+  right <- n %% 10 ^ hl
+  v <- verso(left)
+  if (v < right) return(nconc(leftmid, v))
+  newleftmid <- leftmid - 1
+  newright <- verso(newleftmid %/% 10 ^ (nl - 2 * hl))
+  newleftmid * 10 ^ hl + newright
+}
+
+listify <- \(x) lapply(1:nrow(x), \(i) as.integer(x[i, ]))
+
+palindrome_products <- \(input) {
+  if (input$min > input$max) stop()
+  result <- list()
+  lb <- input$min ^ 2 - 1
+  ub <- input$max ^ 2 + 1
+  cand <- lb
+  while (cand < ub) {
+    cand <- succ(cand)
+    i <- input$min:floor(sqrt(cand))
+    r <- cand %% i
+    w <- which(r == 0)
+    if (length(w) == 0) next
+    i <- i[w]
+    j <- cand %/% i
+    w <- which(j %in% input$min:input$max)
+    if (length(w) == 0) next
+    result$smallest <- list(value = cand, factors = listify(cbind(i[w], j[w])))
+    break
+  }
+  cand <- ub
+  while (cand > lb) {
+    cand <- pred(cand)
+    i <- input$min:floor(sqrt(cand))
+    r <- cand %% i
+    w <- which(r == 0)
+    if (length(w) == 0) next
+    i <- i[w]
+    j <- cand %/% i
+    w <- which(j %in% input$min:input$max)
+    if (length(w) == 0) next
+    result$largest <- list(value = cand, factors = listify(cbind(i[w], j[w])))
+    break
+  }
+  result
+}
+

--- a/exercises/practice/palindrome-products/.meta/tests.toml
+++ b/exercises/practice/palindrome-products/.meta/tests.toml
@@ -1,0 +1,50 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5cff78fe-cf02-459d-85c2-ce584679f887]
+description = "find the smallest palindrome from single digit factors"
+
+[0853f82c-5fc4-44ae-be38-fadb2cced92d]
+description = "find the largest palindrome from single digit factors"
+
+[66c3b496-bdec-4103-9129-3fcb5a9063e1]
+description = "find the smallest palindrome from double digit factors"
+
+[a10682ae-530a-4e56-b89d-69664feafe53]
+description = "find the largest palindrome from double digit factors"
+
+[cecb5a35-46d1-4666-9719-fa2c3af7499d]
+description = "find the smallest palindrome from triple digit factors"
+
+[edab43e1-c35f-4ea3-8c55-2f31dddd92e5]
+description = "find the largest palindrome from triple digit factors"
+
+[4f802b5a-9d74-4026-a70f-b53ff9234e4e]
+description = "find the smallest palindrome from four digit factors"
+
+[787525e0-a5f9-40f3-8cb2-23b52cf5d0be]
+description = "find the largest palindrome from four digit factors"
+
+[58fb1d63-fddb-4409-ab84-a7a8e58d9ea0]
+description = "empty result for smallest if no palindrome in the range"
+
+[9de9e9da-f1d9-49a5-8bfc-3d322efbdd02]
+description = "empty result for largest if no palindrome in the range"
+
+[12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a]
+description = "error result for smallest if min is more than max"
+include = false # redundant, assumes instantiation before calculation of largest and smallest
+
+[eeeb5bff-3f47-4b1e-892f-05829277bd74]
+description = "error result for largest if min is more than max"
+
+[16481711-26c4-42e0-9180-e2e4e8b29c23]
+description = "smallest product does not use the smallest factor"

--- a/exercises/practice/palindrome-products/test_palindrome-products.R
+++ b/exercises/practice/palindrome-products/test_palindrome-products.R
@@ -1,0 +1,87 @@
+source("./palindrome-products.R")
+library(testthat)
+
+
+test_that('find the smallest palindrome from single digit factors', {
+  input <- list(min = 1, max = 9)
+  actual <- palindrome_products(input)$smallest
+  expect_equal(actual$value, 1)
+  expect_equal(actual$factors, list(c(1, 1)))
+})
+
+test_that('find the largest palindrome from single digit factors', {
+  # skip()
+  input <- list(min = 1, max = 9)
+  actual <- palindrome_products(input)$largest
+  expect_equal(actual$value, 9)
+  expect_equal(actual$factors, list(c(1, 9), c(3, 3)))
+})
+
+test_that('find the smallest palindrome from double digit factors', {
+  input <- list(min = 10, max = 99)
+  actual <- palindrome_products(input)$smallest
+  expect_equal(actual$value, 121)
+  expect_equal(actual$factors, list(c(11, 11)))
+})
+
+test_that('find the largest palindrome from double digit factors', {
+  input <- list(min = 10, max = 99)
+  actual <- palindrome_products(input)$largest
+  expect_equal(actual$value, 9009)
+  expect_equal(actual$factors, list(c(91, 99)))
+})
+
+test_that('find the largest palindrome from triple digit factors', {
+  input <- list(min = 100, max = 999)
+  actual <- palindrome_products(input)$largest
+  expect_equal(actual$value, 906609)
+  expect_equal(actual$factors, list(c(913, 993)))
+})
+
+test_that('find the smallest palindrome from four digit factors', {
+  input <- list(min = 1000, max = 9999)
+  actual <- palindrome_products(input)$smallest
+  expect_equal(actual$value, 1002001)
+  expect_equal(actual$factors, list(c(1001, 1001)))
+})
+
+test_that('find the largest palindrome from four digit factors', {
+  input <- list(min = 1000, max = 9999)
+  actual <- palindrome_products(input)$largest
+  expect_equal(actual$value, 99000099)
+  expect_equal(actual$factors, list(c(9901, 9999)))
+})
+
+test_that('empty result for smallest if no palindrome in the range', {
+  input <- list(min = 1002, max = 1003)
+  actual <- palindrome_products(input)$smallest
+  expect_null(actual$value)
+  expect_length(actual$factors, 0)
+})
+
+test_that('empty result for largest if no palindrome in the range', {
+  # skip()
+  input <- list(min = 15, max = 15)
+  actual <- palindrome_products(input)$largest
+  expect_null(actual$value)
+  expect_length(actual$factors, 0)
+})
+
+test_that('error result if min is more than max', {
+  input <- list(min = 10000, max = 1)
+  expect_error(palindrome_products(input))
+})
+
+test_that('smallest product does not use the smallest factor', {
+  input <- list(min = 3215, max = 4000)
+  actual <- palindrome_products(input)$smallest
+  expect_equal(actual$value, 10988901)
+  expect_equal(actual$factors, list(c(3297, 3333)))
+})
+
+test_that('arbitrary range within five digit numbers', {
+  input <- list(min = 33740, max = 58504)
+  actual <- palindrome_products(input)$largest
+  expect_equal(actual$value, 3401441043)
+  expect_equal(actual$factors, list(c(58201, 58443)))
+})


### PR DESCRIPTION
Didn't implement test `[12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a]`, as the schema I used to assumes the `$smallest` and `$largest` are both calculated with every call to `palindrome_products`.