### PR TITLE
Update config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -265,7 +265,7 @@
         "uuid": "366d83ae-a069-457e-ace9-f79417ed311f",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "eliuds-eggs",


### PR DESCRIPTION
The practice exercises were not ordered by difficulty. This is addressed here. 

No particular order has been followed outside of the difficulty level (and keeping `Hello World!` first). 

I didn't look too carefully at which exercises received what rating, but it might be good to have a second look through the difficulty 1 group since that is the default assignment given by configlet, and so it's possible to create a more difficult exercise and miss changing that bit (e.g. is `roman-numerals` a 1?)