### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
-          r-version: 4.3.1
+          r-version: 4.5.2
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
@@ -31,9 +31,10 @@ jobs:
             jsonlite
             dplyr
             stringr
-            readr
             purrr
             tibble
+            lubridate
+            forcats
 
       - name: Run exercism/r ci (runs tests) for all exercises
         run: |


### PR DESCRIPTION
Getting the Strings Concept into reasonable shape is proving a bit of a slog, so here is a small bit of housekeeping meanwhile.

- The `r-version` is bumped to match the test runner.
- The Tidyverse package subset is refined to match what current/future concepts advise students to use. I don't think `readr` is particularly relevant (just maybe to pull in a CSV file?), but we'll want dates and factors handling.

Not here, but maybe something to think about: do we want to restrict this workflow to only run when something relevant has changed? It's really slow (mainly compiling the packages), and currently it runs every time a Markdown file changes in the `concepts` directory.

This is the [Julia version](https://github.com/exercism/julia/blob/main/.github/workflows/exercise-tests.yml), which specifies paths which affect exercises:

```yaml
on:
  workflow_dispatch:
  push:
    branches:
      - main
    paths:
      - "exercises/**"
      - "runtests.jl"
      - ".github/workflows/exercise-tests.yml"
  pull_request:
    paths:
      - "exercises/**"
      - "runtests.jl"
      - ".github/workflows/exercise-tests.yml"
```

The R repo names the `.yml` file differently, but something like this could save us a lot of time when pushing concept stuff.