### PR TITLE
cache-version upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
-          cache-version: 1
+          cache-version: 2
           packages: |
             testthat
             jsonlite


### PR DESCRIPTION
It looks like v2 was released in 2021, so maybe we should start using it? No promises that it will make things better...