### PR TITLE
Update broken link in docs

### DIFF
--- a/concepts/switch/about.md
+++ b/concepts/switch/about.md
@@ -29,7 +29,7 @@ The `switch` in base R is quite limited: it will only do an exact match to a sin
 This seemed reasonable when R was first released in 1993, but needs improvement for modern usage.
 
 ~~~~exercism/note
-As mentioned in the [`Conditionals`][conditionals] Concept, the [`tidyverse`][web-tidyverse] collection of packages is designed to supplement (and sometimes replace) base R functionality without impacting backwards compatibility.
+As mentioned in the [`Conditionals`][concept-conditionals] Concept, the [`tidyverse`][web-tidyverse] collection of packages is designed to supplement (and sometimes replace) base R functionality without impacting backwards compatibility.
 
 The tidyverse packages also have excellent, modern documentation, so following the links below will give more detail.
 

--- a/concepts/switch/introduction.md
+++ b/concepts/switch/introduction.md
@@ -29,7 +29,7 @@ The `switch` in base R is quite limited: it will only do an exact match to a sin
 This seemed reasonable when R was first released in 1993, but needs improvement for modern usage.
 
 ~~~~exercism/note
-As mentioned in the [`Conditionals`][conditionals] Concept, the `tidyverse` collection of packages is designed to supplement (and sometimes replace) base R functionality without impacting backwards compatibility.
+As mentioned in the [`Conditionals`][concept-conditionals] Concept, the `tidyverse` collection of packages is designed to supplement (and sometimes replace) base R functionality without impacting backwards compatibility.
 
 The `dplyr` package can be brought into scope by adding either `library(dplyr)` (for the single package) or `library(tidyverse)` (for the whole collection) to the top of your code.
 

--- a/exercises/concept/blackjack/.docs/introduction.md
+++ b/exercises/concept/blackjack/.docs/introduction.md
@@ -29,7 +29,7 @@ The `switch` in base R is quite limited: it will only do an exact match to a sin
 This seemed reasonable when R was first released in 1993, but needs improvement for modern usage.
 
 ~~~~exercism/note
-As mentioned in the [`Conditionals`][conditionals] Concept, the `tidyverse` collection of packages is designed to supplement (and sometimes replace) base R functionality without impacting backwards compatibility.
+As mentioned in the [`Conditionals`][concept-conditionals] Concept, the `tidyverse` collection of packages is designed to supplement (and sometimes replace) base R functionality without impacting backwards compatibility.
 
 The `dplyr` package can be brought into scope by adding either `library(dplyr)` (for the single package) or `library(tidyverse)` (for the whole collection) to the top of your code.
 


### PR DESCRIPTION
Just a slight rename of a link to match the definition. Also, this may help push the website to see the `switch` concept.