### PR TITLE
[Test Generator]: Fixed up Tuple Filter to Check for `ints` & `floats` and not quote them

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -189,6 +189,9 @@ def list_to_tuple(case_array: List[str]) -> tuple[str] | str:
     """
 
     if len(case_array) == 1:
+        if isinstance(case_array[0], int) or isinstance(case_array[0], float):
+            return f'({case_array[0]})'
+
         return f"('{case_array[0]}')"
 
     return tuple(case_array)
@@ -420,7 +423,7 @@ def generate(
     """
     # air must be installed or all test files will error
     if not shutil.which("air"):
-        logger.error("the air utility must be installed")
+        logger.error("the air-formatter utility must be installed")
         sys.exit(1)
     loader = FileSystemLoader(["config", "exercises"])
     env = Environment(loader=loader, keep_trailing_newline=True)


### PR DESCRIPTION
```python
def list_to_tuple(case_array: List[str]) -> tuple[str] | str:
    """
    Turns JSON list into Tuple.

    This helps with easier conversion to R-style vectors
    in the JinJa templates.

    Because `c()` in R does not tolerate a trailing comma,
    we return an f-string when the input array is only one item.
    """

    if len(case_array) == 1:
        if isinstance(case_array[0], int) or isinstance(case_array[0], float):
            return f'({case_array[0]})'

        return f"('{case_array[0]}')"

    return tuple(case_array)
```

Tested on `Anagram` and `Flatten-Array`, but did not test with data that had a singleton `float`.