### PR TITLE
update canonical testing

### DIFF
--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,150 +1,160 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
-description = "not allergic to anything"
+description = "testing for eggs allergy -> not allergic to anything"
 
 [07ced27b-1da5-4c2e-8ae2-cb2791437546]
-description = "allergic only to eggs"
+description = "testing for eggs allergy -> allergic only to eggs"
 
 [5035b954-b6fa-4b9b-a487-dae69d8c5f96]
-description = "allergic to eggs and something else"
+description = "testing for eggs allergy -> allergic to eggs and something else"
 
 [64a6a83a-5723-4b5b-a896-663307403310]
-description = "allergic to something, but not eggs"
+description = "testing for eggs allergy -> allergic to something, but not eggs"
 
 [90c8f484-456b-41c4-82ba-2d08d93231c6]
-description = "allergic to everything"
+description = "testing for eggs allergy -> allergic to everything"
 
 [d266a59a-fccc-413b-ac53-d57cb1f0db9d]
-description = "not allergic to anything"
+description = "testing for peanuts allergy -> not allergic to anything"
 
 [ea210a98-860d-46b2-a5bf-50d8995b3f2a]
-description = "allergic only to peanuts"
+description = "testing for peanuts allergy -> allergic only to peanuts"
 
 [eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
-description = "allergic to peanuts and something else"
+description = "testing for peanuts allergy -> allergic to peanuts and something else"
 
 [9152058c-ce39-4b16-9b1d-283ec6d25085]
-description = "allergic to something, but not peanuts"
+description = "testing for peanuts allergy -> allergic to something, but not peanuts"
 
 [d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
-description = "allergic to everything"
+description = "testing for peanuts allergy -> allergic to everything"
 
 [b948b0a1-cbf7-4b28-a244-73ff56687c80]
-description = "not allergic to anything"
+description = "testing for shellfish allergy -> not allergic to anything"
 
 [9ce9a6f3-53e9-4923-85e0-73019047c567]
-description = "allergic only to shellfish"
+description = "testing for shellfish allergy -> allergic only to shellfish"
 
 [b272fca5-57ba-4b00-bd0c-43a737ab2131]
-description = "allergic to shellfish and something else"
+description = "testing for shellfish allergy -> allergic to shellfish and something else"
 
 [21ef8e17-c227-494e-8e78-470a1c59c3d8]
-description = "allergic to something, but not shellfish"
+description = "testing for shellfish allergy -> allergic to something, but not shellfish"
 
 [cc789c19-2b5e-4c67-b146-625dc8cfa34e]
-description = "allergic to everything"
+description = "testing for shellfish allergy -> allergic to everything"
 
 [651bde0a-2a74-46c4-ab55-02a0906ca2f5]
-description = "not allergic to anything"
+description = "testing for strawberries allergy -> not allergic to anything"
 
 [b649a750-9703-4f5f-b7f7-91da2c160ece]
-description = "allergic only to strawberries"
+description = "testing for strawberries allergy -> allergic only to strawberries"
 
 [50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
-description = "allergic to strawberries and something else"
+description = "testing for strawberries allergy -> allergic to strawberries and something else"
 
 [23dd6952-88c9-48d7-a7d5-5d0343deb18d]
-description = "allergic to something, but not strawberries"
+description = "testing for strawberries allergy -> allergic to something, but not strawberries"
 
 [74afaae2-13b6-43a2-837a-286cd42e7d7e]
-description = "allergic to everything"
+description = "testing for strawberries allergy -> allergic to everything"
 
 [c49a91ef-6252-415e-907e-a9d26ef61723]
-description = "not allergic to anything"
+description = "testing for tomatoes allergy -> not allergic to anything"
 
 [b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
-description = "allergic only to tomatoes"
+description = "testing for tomatoes allergy -> allergic only to tomatoes"
 
 [1ca50eb1-f042-4ccf-9050-341521b929ec]
-description = "allergic to tomatoes and something else"
+description = "testing for tomatoes allergy -> allergic to tomatoes and something else"
 
 [e9846baa-456b-4eff-8025-034b9f77bd8e]
-description = "allergic to something, but not tomatoes"
+description = "testing for tomatoes allergy -> allergic to something, but not tomatoes"
 
 [b2414f01-f3ad-4965-8391-e65f54dad35f]
-description = "allergic to everything"
+description = "testing for tomatoes allergy -> allergic to everything"
 
 [978467ab-bda4-49f7-b004-1d011ead947c]
-description = "not allergic to anything"
+description = "testing for chocolate allergy -> not allergic to anything"
 
 [59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
-description = "allergic only to chocolate"
+description = "testing for chocolate allergy -> allergic only to chocolate"
 
 [b0a7c07b-2db7-4f73-a180-565e07040ef1]
-description = "allergic to chocolate and something else"
+description = "testing for chocolate allergy -> allergic to chocolate and something else"
 
 [f5506893-f1ae-482a-b516-7532ba5ca9d2]
-description = "allergic to something, but not chocolate"
+description = "testing for chocolate allergy -> allergic to something, but not chocolate"
 
 [02debb3d-d7e2-4376-a26b-3c974b6595c6]
-description = "allergic to everything"
+description = "testing for chocolate allergy -> allergic to everything"
 
 [17f4a42b-c91e-41b8-8a76-4797886c2d96]
-description = "not allergic to anything"
+description = "testing for pollen allergy -> not allergic to anything"
 
 [7696eba7-1837-4488-882a-14b7b4e3e399]
-description = "allergic only to pollen"
+description = "testing for pollen allergy -> allergic only to pollen"
 
 [9a49aec5-fa1f-405d-889e-4dfc420db2b6]
-description = "allergic to pollen and something else"
+description = "testing for pollen allergy -> allergic to pollen and something else"
 
 [3cb8e79f-d108-4712-b620-aa146b1954a9]
-description = "allergic to something, but not pollen"
+description = "testing for pollen allergy -> allergic to something, but not pollen"
 
 [1dc3fe57-7c68-4043-9d51-5457128744b2]
-description = "allergic to everything"
+description = "testing for pollen allergy -> allergic to everything"
 
 [d3f523d6-3d50-419b-a222-d4dfd62ce314]
-description = "not allergic to anything"
+description = "testing for cats allergy -> not allergic to anything"
 
 [eba541c3-c886-42d3-baef-c048cb7fcd8f]
-description = "allergic only to cats"
+description = "testing for cats allergy -> allergic only to cats"
 
 [ba718376-26e0-40b7-bbbe-060287637ea5]
-description = "allergic to cats and something else"
+description = "testing for cats allergy -> allergic to cats and something else"
 
 [3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
-description = "allergic to something, but not cats"
+description = "testing for cats allergy -> allergic to something, but not cats"
 
 [1faabb05-2b98-4995-9046-d83e4a48a7c1]
-description = "allergic to everything"
+description = "testing for cats allergy -> allergic to everything"
 
 [f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
-description = "no allergies"
+description = "list when: -> no allergies"
 
 [9e1a4364-09a6-4d94-990f-541a94a4c1e8]
-description = "just eggs"
+description = "list when: -> just eggs"
 
 [8851c973-805e-4283-9e01-d0c0da0e4695]
-description = "just peanuts"
+description = "list when: -> just peanuts"
 
 [2c8943cb-005e-435f-ae11-3e8fb558ea98]
-description = "just strawberries"
+description = "list when: -> just strawberries"
 
 [6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
-description = "eggs and peanuts"
+description = "list when: -> eggs and peanuts"
 
 [19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
-description = "more than eggs but not peanuts"
+description = "list when: -> more than eggs but not peanuts"
 
 [4b68f470-067c-44e4-889f-c9fe28917d2f]
-description = "lots of stuff"
+description = "list when: -> lots of stuff"
 
 [0881b7c5-9efa-4530-91bd-68370d054bc7]
-description = "everything"
+description = "list when: -> everything"
 
 [12ce86de-b347-42a0-ab7c-2e0570f0c65b]
-description = "no allergen score parts"
+description = "list when: -> no allergen score parts"
+
+[93c2df3e-4f55-4fed-8116-7513092819cd]
+description = "list when: -> no allergen score parts without highest valid score"

--- a/exercises/practice/allergies/test_allergies.R
+++ b/exercises/practice/allergies/test_allergies.R
@@ -85,3 +85,11 @@ test_that("ignore non allergen score parts", {
     )
   ))
 })
+
+test_that("ignore non allergen score parts", {
+  x <- allergy(257)
+  expect_true(setequal(
+    list_allergies(x),
+    c("eggs")
+  ))
+})

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -1,9 +1,19 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
+
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
 
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"
@@ -22,3 +32,8 @@ description = "8 character plaintext results in 3 chunks, the last one with a tr
 
 [fbcb0c6d-4c39-4a31-83f6-c473baa6af80]
 description = "54 character plaintext results in 7 chunks, the last two with trailing spaces"
+include = false
+
+[33fd914e-fa44-445b-8f38-ff8fbc9fe6e6]
+description = "54 character plaintext results in 8 chunks, the last two with trailing spaces"
+reimplements = "fbcb0c6d-4c39-4a31-83f6-c473baa6af80"

--- a/exercises/practice/crypto-square/test_crypto-square.R
+++ b/exercises/practice/crypto-square/test_crypto-square.R
@@ -63,12 +63,15 @@ test_that("9 character plaintext results in 3 chunks of 3 characters", {
   expect_equal(ciphertext("This is fun!"), "tsf hiu isn")
 })
 
-test_that("54 character plaintext results in 7 chunks, the last two padded with
-          spaces", {
+test_that("54 character plaintext results in 8 chunks, the last two with trailing spaces", {
   expect_equal(
     ciphertext(
       "If man was meant to stay on the ground, god would have given us roots."
     ),
     "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
   )
+})
+
+test_that("normalization results in empty plaintext", {
+  expect_equal(ciphertext("... --- ..."), "")
 })

--- a/exercises/practice/tournament/.meta/tests.toml
+++ b/exercises/practice/tournament/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [67e9fab1-07c1-49cf-9159-bc8671cc7c9c]
 description = "just the header if no input"
@@ -34,3 +41,6 @@ description = "incomplete competition (not all pairs have played)"
 
 [3aa0386f-150b-4f99-90bb-5195e7b7d3b8]
 description = "ties broken alphabetically"
+
+[f9e20931-8a65-442a-81f6-503c0205b17a]
+description = "ensure points sorted numerically"

--- a/exercises/practice/tournament/test_tournament.R
+++ b/exercises/practice/tournament/test_tournament.R
@@ -185,3 +185,27 @@ test_that("invalid match result", {
     )
   )
 })
+
+test_that("ensure points sorted numerically", {
+  input <- c(
+    "Devastating Donkeys;Blithering Badgers;win",
+    "Devastating Donkeys;Blithering Badgers;win",
+    "Devastating Donkeys;Blithering Badgers;win",
+    "Devastating Donkeys;Blithering Badgers;win",
+    "Blithering Badgers;Devastating Donkeys;win"
+  )
+  expect_equal(
+    tournament(input),
+    data.frame(
+      Team = c(
+        "Devastating Donkeys",
+        "Blithering Badgers"
+      ),
+      MP = c(5, 5),
+      W = c(4, 1),
+      D = c(0, 0),
+      L = c(1, 4),
+      P = c(12, 3)
+    )
+  )
+})

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,60 +1,73 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [8b2c43ac-7257-43f9-b552-7631a91988af]
-description = "all sides are equal"
+description = "equilateral triangle -> all sides are equal"
 
 [33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
-description = "any side is unequal"
+description = "equilateral triangle -> any side is unequal"
 
 [c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
-description = "no sides are equal"
+description = "equilateral triangle -> no sides are equal"
 
 [16e8ceb0-eadb-46d1-b892-c50327479251]
-description = "all zero sides is not a triangle"
+description = "equilateral triangle -> all zero sides is not a triangle"
 
 [3022f537-b8e5-4cc1-8f12-fd775827a00c]
-description = "sides may be floats"
+description = "equilateral triangle -> sides may be floats"
 
 [cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
-description = "last two sides are equal"
+description = "isosceles triangle -> last two sides are equal"
 
 [e388ce93-f25e-4daf-b977-4b7ede992217]
-description = "first two sides are equal"
+description = "isosceles triangle -> first two sides are equal"
 
 [d2080b79-4523-4c3f-9d42-2da6e81ab30f]
-description = "first and last sides are equal"
+description = "isosceles triangle -> first and last sides are equal"
 
 [8d71e185-2bd7-4841-b7e1-71689a5491d8]
-description = "equilateral triangles are also isosceles"
+description = "isosceles triangle -> equilateral triangles are also isosceles"
 
 [840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
-description = "no sides are equal"
+description = "isosceles triangle -> no sides are equal"
 
 [2eba0cfb-6c65-4c40-8146-30b608905eae]
-description = "first triangle inequality violation"
+description = "isosceles triangle -> first triangle inequality violation"
 
 [278469cb-ac6b-41f0-81d4-66d9b828f8ac]
-description = "second triangle inequality violation"
+description = "isosceles triangle -> second triangle inequality violation"
 
 [90efb0c7-72bb-4514-b320-3a3892e278ff]
-description = "third triangle inequality violation"
+description = "isosceles triangle -> third triangle inequality violation"
 
 [adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
-description = "sides may be floats"
+description = "isosceles triangle -> sides may be floats"
 
 [e8b5f09c-ec2e-47c1-abec-f35095733afb]
-description = "no sides are equal"
+description = "scalene triangle -> no sides are equal"
 
 [2510001f-b44d-4d18-9872-2303e7977dc1]
-description = "all sides are equal"
+description = "scalene triangle -> all sides are equal"
 
 [c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
-description = "two sides are equal"
+description = "scalene triangle -> first and second sides are equal"
+
+[3da23a91-a166-419a-9abf-baf4868fd985]
+description = "scalene triangle -> first and third sides are equal"
+
+[b6a75d98-1fef-4c42-8e9a-9db854ba0a4d]
+description = "scalene triangle -> second and third sides are equal"
 
 [70ad5154-0033-48b7-af2c-b8d739cd9fdc]
-description = "may not violate triangle inequality"
+description = "scalene triangle -> may not violate triangle inequality"
 
 [26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
-description = "sides may be floats"
+description = "scalene triangle -> sides may be floats"

--- a/exercises/practice/triangle/test_triangle.R
+++ b/exercises/practice/triangle/test_triangle.R
@@ -61,6 +61,14 @@ test_that("not scalene if two sides are equal", {
   expect_false(any("scalene" %in% class(triangle(4, 4, 3))))
 })
 
+test_that("not scalene if first and third sides are equal", {
+  expect_false(any("scalene" %in% class(triangle(3, 4, 3))))
+})
+
+test_that("not scalene if second and third sides are equal", {
+  expect_false(any("scalene" %in% class(triangle(4, 3, 3))))
+})
+
 test_that("not scalene if triangle inequality is violated", {
   expect_error(triangle(7, 3, 2))
 })


### PR DESCRIPTION
This manually updates the canonical tests in the more cantankerous group of exercises:

- `allergies`
- `crypto-square`
- `tournament`
- `triangle`

This includes adding the missing exercises and updating the respective `tests.toml`. No `example.R` were changed in the process.

As an aside: I feel that I may be able to come up with at template for `allergies` if/when I figure out how to deal with nested `canonical-data`.