### PR TITLE
[Test Templates]: Diamond, ETL, Grains, and Resistor-Color

### DIFF
--- a/exercises/practice/diamond/.meta/template.j2
+++ b/exercises/practice/diamond/.meta/template.j2
@@ -1,0 +1,16 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header() }}
+
+{% for case in cases -%}
+test_that("{{ case["description"] }}", {
+  input <- "{{ case["input"]["letter"] }}"
+  expected <- c{{ case["expected"] | list_to_tuple }}
+  expect_equal(
+    diamond(input),
+    paste(collapse= "\n", expected)
+  )
+})
+
+{% endfor %}

--- a/exercises/practice/diamond/test_diamond.R
+++ b/exercises/practice/diamond/test_diamond.R
@@ -1,96 +1,111 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/diamond/canonical-data.json
+# File last updated on 2026-03-19
+
 source("./diamond.R")
 library(testthat)
 
 test_that("Degenerate case with a single 'A' row", {
-  expect_equal(diamond("A"), "A")
+  input <- "A"
+  expected <- c('A')
+  expect_equal(
+    diamond(input),
+    paste(collapse = "\n", expected)
+  )
 })
 
-test_that("Degenerate case with no row having 3 distinct groups of spaces", {
-  expect_equal(diamond("B"), paste(
-    sep = "\n",
-    " A ",
-    "B B",
-    " A "
-  ))
+test_that("Degenerate case with no row containing 3 distinct groups of spaces", {
+  input <- "B"
+  expected <- c(' A ', 'B B', ' A ')
+  expect_equal(
+    diamond(input),
+    paste(collapse = "\n", expected)
+  )
 })
 
 test_that("Smallest non-degenerate case with odd diamond side length", {
-  expect_equal(diamond("C"), paste(
-    sep = "\n",
-    "  A  ",
-    " B B ",
-    "C   C",
-    " B B ",
-    "  A  "
-  ))
+  input <- "C"
+  expected <- c('  A  ', ' B B ', 'C   C', ' B B ', '  A  ')
+  expect_equal(
+    diamond(input),
+    paste(collapse = "\n", expected)
+  )
 })
 
 test_that("Smallest non-degenerate case with even diamond side length", {
-  expect_equal(diamond("D"), paste(
-    sep = "\n",
-    "   A   ",
-    "  B B  ",
-    " C   C ",
-    "D     D",
-    " C   C ",
-    "  B B  ",
-    "   A   "
-  ))
+  input <- "D"
+  expected <- c(
+    '   A   ',
+    '  B B  ',
+    ' C   C ',
+    'D     D',
+    ' C   C ',
+    '  B B  ',
+    '   A   '
+  )
+  expect_equal(
+    diamond(input),
+    paste(collapse = "\n", expected)
+  )
 })
 
 test_that("Largest possible diamond", {
-  expect_equal(diamond("Z"), paste(
-    sep = "\n",
-    "                         A                         ",
-    "                        B B                        ",
-    "                       C   C                       ",
-    "                      D     D                      ",
-    "                     E       E                     ",
-    "                    F         F                    ",
-    "                   G           G                   ",
-    "                  H             H                  ",
-    "                 I               I                 ",
-    "                J                 J                ",
-    "               K                   K               ",
-    "              L                     L              ",
-    "             M                       M             ",
-    "            N                         N            ",
-    "           O                           O           ",
-    "          P                             P          ",
-    "         Q                               Q         ",
-    "        R                                 R        ",
-    "       S                                   S       ",
-    "      T                                     T      ",
-    "     U                                       U     ",
-    "    V                                         V    ",
-    "   W                                           W   ",
-    "  X                                             X  ",
-    " Y                                               Y ",
-    "Z                                                 Z",
-    " Y                                               Y ",
-    "  X                                             X  ",
-    "   W                                           W   ",
-    "    V                                         V    ",
-    "     U                                       U     ",
-    "      T                                     T      ",
-    "       S                                   S       ",
-    "        R                                 R        ",
-    "         Q                               Q         ",
-    "          P                             P          ",
-    "           O                           O           ",
-    "            N                         N            ",
-    "             M                       M             ",
-    "              L                     L              ",
-    "               K                   K               ",
-    "                J                 J                ",
-    "                 I               I                 ",
-    "                  H             H                  ",
-    "                   G           G                   ",
-    "                    F         F                    ",
-    "                     E       E                     ",
-    "                      D     D                      ",
-    "                       C   C                       ",
-    "                        B B                        ",
-    "                         A                         "
-  ))
+  input <- "Z"
+  expected <- c(
+    '                         A                         ',
+    '                        B B                        ',
+    '                       C   C                       ',
+    '                      D     D                      ',
+    '                     E       E                     ',
+    '                    F         F                    ',
+    '                   G           G                   ',
+    '                  H             H                  ',
+    '                 I               I                 ',
+    '                J                 J                ',
+    '               K                   K               ',
+    '              L                     L              ',
+    '             M                       M             ',
+    '            N                         N            ',
+    '           O                           O           ',
+    '          P                             P          ',
+    '         Q                               Q         ',
+    '        R                                 R        ',
+    '       S                                   S       ',
+    '      T                                     T      ',
+    '     U                                       U     ',
+    '    V                                         V    ',
+    '   W                                           W   ',
+    '  X                                             X  ',
+    ' Y                                               Y ',
+    'Z                                                 Z',
+    ' Y                                               Y ',
+    '  X                                             X  ',
+    '   W                                           W   ',
+    '    V                                         V    ',
+    '     U                                       U     ',
+    '      T                                     T      ',
+    '       S                                   S       ',
+    '        R                                 R        ',
+    '         Q                               Q         ',
+    '          P                             P          ',
+    '           O                           O           ',
+    '            N                         N            ',
+    '             M                       M             ',
+    '              L                     L              ',
+    '               K                   K               ',
+    '                J                 J                ',
+    '                 I               I                 ',
+    '                  H             H                  ',
+    '                   G           G                   ',
+    '                    F         F                    ',
+    '                     E       E                     ',
+    '                      D     D                      ',
+    '                       C   C                       ',
+    '                        B B                        ',
+    '                         A                         '
+  )
+  expect_equal(
+    diamond(input),
+    paste(collapse = "\n", expected)
+  )
 })

--- a/exercises/practice/etl/.meta/template.j2
+++ b/exercises/practice/etl/.meta/template.j2
@@ -1,0 +1,19 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header() }}
+
+{% for case in cases -%}
+test_that("{{ case["description"] }}", {
+        input <- list(
+        {%- for key in case["input"]["legacy"]  -%}
+        '{{ key }}' = c{{ case["input"]["legacy"][ key ] | list_to_tuple }}{{ "," if not loop.last }}
+        {% endfor %})
+      expected <- list(
+        {%-  for key in case["expected"]  -%}
+        {{ key | lower }} = {{ case["expected"][key] }}{{ "," if not loop.last }}
+        {% endfor %})
+  expect_equal(etl(input), expected)
+})
+
+{% endfor %}

--- a/exercises/practice/etl/test_etl.R
+++ b/exercises/practice/etl/test_etl.R
@@ -1,82 +1,65 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/etl/canonical-data.json
+# File last updated on 2026-03-19
+
 source("./etl.R")
 library(testthat)
 
 test_that("single letter", {
-  expect_equal(etl(list("1" = "A")), list(a = 1))
+  input <- list('1' = c('A'))
+  expected <- list(a = 1)
+  expect_equal(etl(input), expected)
 })
 
 test_that("single score with multiple letters", {
-  expect_equal(
-    etl(
-      list("1" = c("A", "E", "I", "O", "U"))
-    ),
-    list(
-      a = 1,
-      e = 1,
-      i = 1,
-      o = 1,
-      u = 1
-    )
-  )
+  input <- list('1' = c('A', 'E', 'I', 'O', 'U'))
+  expected <- list(a = 1, e = 1, i = 1, o = 1, u = 1)
+  expect_equal(etl(input), expected)
 })
 
 test_that("multiple scores with multiple letters", {
-  expect_equal(
-    etl(
-      list(
-        "1" = c("A", "E"),
-        "2" = c("D", "G")
-      )
-    ),
-    list(
-      a = 1,
-      d = 2,
-      e = 1,
-      g = 2
-    )
-  )
+  input <- list('1' = c('A', 'E'), '2' = c('D', 'G'))
+  expected <- list(a = 1, d = 2, e = 1, g = 2)
+  expect_equal(etl(input), expected)
 })
 
-test_that("multiple scores with multiple letters", {
-  expect_equal(
-    etl(
-      list(
-        "1" = c("A", "E", "I", "O", "U", "L", "N", "R", "S", "T"),
-        "2" = c("D", "G"),
-        "3" = c("B", "C", "M", "P"),
-        "4" = c("F", "H", "V", "W", "Y"),
-        "5" = c("K"),
-        "8" = c("J", "X"),
-        "10" = c("Q", "Z")
-      )
-    ),
-    list(
-      a = 1,
-      b = 3,
-      c = 3,
-      d = 2,
-      e = 1,
-      f = 4,
-      g = 2,
-      h = 4,
-      i = 1,
-      j = 8,
-      k = 5,
-      l = 1,
-      m = 3,
-      n = 1,
-      o = 1,
-      p = 3,
-      q = 10,
-      r = 1,
-      s = 1,
-      t = 1,
-      u = 1,
-      v = 4,
-      w = 4,
-      x = 8,
-      y = 4,
-      z = 10
-    )
+test_that("multiple scores with differing numbers of letters", {
+  input <- list(
+    '1' = c('A', 'E', 'I', 'O', 'U', 'L', 'N', 'R', 'S', 'T'),
+    '2' = c('D', 'G'),
+    '3' = c('B', 'C', 'M', 'P'),
+    '4' = c('F', 'H', 'V', 'W', 'Y'),
+    '5' = c('K'),
+    '8' = c('J', 'X'),
+    '10' = c('Q', 'Z')
   )
+  expected <- list(
+    a = 1,
+    b = 3,
+    c = 3,
+    d = 2,
+    e = 1,
+    f = 4,
+    g = 2,
+    h = 4,
+    i = 1,
+    j = 8,
+    k = 5,
+    l = 1,
+    m = 3,
+    n = 1,
+    o = 1,
+    p = 3,
+    q = 10,
+    r = 1,
+    s = 1,
+    t = 1,
+    u = 1,
+    v = 4,
+    w = 4,
+    x = 8,
+    y = 4,
+    z = 10
+  )
+  expect_equal(etl(input), expected)
 })

--- a/exercises/practice/grains/.meta/template.j2
+++ b/exercises/practice/grains/.meta/template.j2
@@ -1,0 +1,33 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header() }}
+
+{% for case in cases -%}
+{% for subcase in case["cases"] %}
+    {%- set description = subcase["description"] -%}
+    {%- set property = subcase["property"] -%}
+    {%- set input = subcase["input"]["square"] -%}
+    {%- if subcase["expected"]["error"] -%}
+        {% set expected = "error" -%}
+    {%- else -%}
+        {% set expected = subcase["expected"] -%}
+    {%- endif -%}
+    test_that("{{ description }}", {
+    {%- if expected == "error"  -%}
+    input <- {{ subcase["input"]["square"] }}
+    expect_error(square(input))
+    {%- else -%}
+    input <- {{ input }}
+    expected <- {{ expected }}
+    expect_equal(square(input), expected)
+    {%- endif -%}
+    })
+
+{% endfor -%}
+    {%- if case["property"] == "total" -%}
+    test_that("{{ case["description"] }}", {
+    expect_equal(total(), {{ case["expected"] }})
+    })
+    {%- endif -%}
+{%- endfor %}

--- a/exercises/practice/grains/test_grains.R
+++ b/exercises/practice/grains/test_grains.R
@@ -1,46 +1,67 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
+# File last updated on 2026-03-20
+
 source("./grains.R")
 library(testthat)
 
-test_that("Case 1", {
-  expect_equal(square(1), 1)
+test_that("grains on square 1", {
+  input <- 1
+  expected <- 1
+  expect_equal(square(input), expected)
 })
 
-test_that("Case 2", {
-  expect_equal(square(2), 2)
+test_that("grains on square 2", {
+  input <- 2
+  expected <- 2
+  expect_equal(square(input), expected)
 })
 
-test_that("Case 3", {
-  expect_equal(square(3), 4)
+test_that("grains on square 3", {
+  input <- 3
+  expected <- 4
+  expect_equal(square(input), expected)
 })
 
-test_that("Case 4", {
-  expect_equal(square(4), 8)
+test_that("grains on square 4", {
+  input <- 4
+  expected <- 8
+  expect_equal(square(input), expected)
 })
 
-test_that("Case 16", {
-  expect_equal(square(16), 32768)
+test_that("grains on square 16", {
+  input <- 16
+  expected <- 32768
+  expect_equal(square(input), expected)
 })
 
-test_that("Case 32", {
-  expect_equal(square(32), 2147483648)
+test_that("grains on square 32", {
+  input <- 32
+  expected <- 2147483648
+  expect_equal(square(input), expected)
 })
 
-test_that("Case 1", {
-  expect_equal(square(64), 9223372036854775808)
+test_that("grains on square 64", {
+  input <- 64
+  expected <- 9223372036854775808
+  expect_equal(square(input), expected)
 })
 
-test_that("square 0 raises an exception", {
-  expect_error(square(0))
+test_that("square 0 is invalid", {
+  input <- 0
+  expect_error(square(input))
 })
 
-test_that("negative square raises an exception", {
-  expect_error(square(-1))
+test_that("negative square is invalid", {
+  input <- -1
+  expect_error(square(input))
 })
 
-test_that("square greater than 64 raises an exception", {
-  expect_error(square(65))
+test_that("square greater than 64 is invalid", {
+  input <- 65
+  expect_error(square(input))
 })
 
-test_that("returns the total number of square on the board", {
+test_that("returns the total number of grains on the board", {
   expect_equal(total(), 18446744073709551615)
 })

--- a/exercises/practice/resistor-color/.meta/template.j2
+++ b/exercises/practice/resistor-color/.meta/template.j2
@@ -1,0 +1,24 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header() }}
+
+{% for case in cases -%}
+{% for subcase in case["cases"] %}
+    {%- set description = subcase["description"] -%}
+    {%- set property = subcase["property"] -%}
+    {%- set input = subcase["input"]["color"] | lower -%}
+    {%- set expected = subcase["expected"] -%}
+    test_that("{{ description }}", {
+    input <- "{{ input }}"
+    expected <- {{ expected }}
+    expect_equal(color_code(input), expected)
+    })
+
+{% endfor -%}
+    {%- if case["property"] == "colors" -%}
+    test_that("{{ case["description"] }}", {
+    expect_equal(colors, c{{ case["expected"] | list_to_tuple}})
+    })
+    {%- endif -%}
+{%- endfor %}

--- a/exercises/practice/resistor-color/test_resistor-color.R
+++ b/exercises/practice/resistor-color/test_resistor-color.R
@@ -1,19 +1,42 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color/canonical-data.json
+# File last updated on 2026-03-20
+
 source("./resistor-color.R")
 library(testthat)
 
-test_that("Colors", {
-  expected <- c("black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white") # nolint
-  expect_equal(colors, expected)
-})
-
 test_that("Black", {
-  expect_equal(color_code("black"), 0)
+  input <- "black"
+  expected <- 0
+  expect_equal(color_code(input), expected)
 })
 
 test_that("White", {
-  expect_equal(color_code("white"), 9)
+  input <- "white"
+  expected <- 9
+  expect_equal(color_code(input), expected)
 })
 
 test_that("Orange", {
-  expect_equal(color_code("orange"), 3)
+  input <- "orange"
+  expected <- 3
+  expect_equal(color_code(input), expected)
+})
+
+test_that("Colors", {
+  expect_equal(
+    colors,
+    c(
+      'black',
+      'brown',
+      'red',
+      'orange',
+      'yellow',
+      'green',
+      'blue',
+      'violet',
+      'grey',
+      'white'
+    )
+  )
 })


### PR DESCRIPTION
Added JinJa templates, regenerated test files, and re-tested example files:

- [x] Diamond
- [x] ETL
- [x] Grains
- [x] Resistor-Color

Wow, did `Grains` and `Resistor-Color` try my patience.  Nesting with identical keys in problem specs.  Yuck.
OTOH, `ETL` was .. fun?  I learned all about `if not loop.last`.  😉 
