### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.
 
 The instructions above refer to "lists" in the general sense and not to the `list()` data type in R.

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 R supports complex numbers as a core type: for details see [here][complex1] and [here][complex2].
 The purpose of this exercise is to implement them from scratch, _without_ using the built-in functions.
 

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-### Bonus tests
+# Instructions append
+
+## Bonus tests
 
 Enable tests with grapheme clusters by uncommenting (or defining) `enable_grapheme_clusters <- TRUE`.
 

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,3 +1,6 @@
+# Instructions append
+
 ## Hint
 
-For this exercise you will need to implement a simple S3 class via its constructor, generic method and dispatch to class method. If you are not familiar with S3, a great starting point is the [chapter on S3](http://adv-r.hadley.nz/s3.html) in Hadley Wickham's book Advanced R.
+For this exercise you will need to implement a simple S3 class via its constructor, generic method and dispatch to class method.
+If you are not familiar with S3, a great starting point is the [chapter on S3](http://adv-r.hadley.nz/s3.html) in Hadley Wickham's book Advanced R.

--- a/exercises/practice/sieve/.docs/instructions.append.md
+++ b/exercises/practice/sieve/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Notice that this is a very specific algorithm that requires **not** to use division or derived operations (remainder, square root, exponent etc.).

--- a/exercises/practice/sublist/.docs/instructions.append.md
+++ b/exercises/practice/sublist/.docs/instructions.append.md
@@ -1,4 +1,6 @@
 # Instructions append
 
+## Implementation
+
 Whilst the instructions refer to working with lists, in R the vector type is a more common collection type.
 Hence, you should read "vector" whenever "list" is mentioned.

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -1,4 +1,6 @@
+# Instructions append
 
 ## Hint
 
-For this exercise you will need to implement a simple S3 class. If you are not familiar with S3, a great starting point is the [chapter on S3](http://adv-r.hadley.nz/s3.html) in Hadley Wickham's book Advanced R.
+For this exercise you will need to implement a simple S3 class.
+If you are not familiar with S3, a great starting point is the [chapter on S3](http://adv-r.hadley.nz/s3.html) in Hadley Wickham's book Advanced R.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.