### PR TITLE
add concept exercise trees-and-tribbleations

### DIFF
--- a/config.json
+++ b/config.json
@@ -236,6 +236,17 @@
           "functional-programming"
         ],
         "status": "wip"
+      },
+      {
+        "slug": "trees-and-tibbleations",
+        "name": "Trees & Tibble-ations",
+        "uuid": "7a4e7305-dfaf-473a-8b41-2b8586541a28",
+        "concepts": [
+          "dataframes"
+        ],
+        "prerequisites": [
+          "functional-programming"
+        ]
       }
     ],
     "practice": [

--- a/config.json
+++ b/config.json
@@ -246,7 +246,8 @@
         ],
         "prerequisites": [
           "functional-programming"
-        ]
+        ],
+        "status": "wip"
       }
     ],
     "practice": [

--- a/exercises/concept/trees-and-tibbleations/.docs/hints.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/hints.md
@@ -16,8 +16,7 @@
 
 - You need to move columns around and sort rows (see the Introduction).
 - The [`all_of()`][ref-allof] function may be useful for moving columns.
-- `arrange()` will silently fail if not given a proper column name (i.e. it doesn't like character strings)
-- `.data[[]]` or [`pick()`][ref-pick] might be useful for the sorting operation.
+- See caution in the introduction about [data-masking][ref-datamask] which mentions [`pick()`][ref-pick].
 
 ## 4. Customer copy of dataset
 
@@ -27,3 +26,4 @@
 
 [ref-allof]: https://tidyselect.r-lib.org/reference/all_of.html
 [ref-pick]: https://dplyr.tidyverse.org/reference/pick.html
+[ref-datamask]: https://rlang.r-lib.org/reference/args_data_masking.html

--- a/exercises/concept/trees-and-tibbleations/.docs/hints.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/hints.md
@@ -15,11 +15,14 @@
 ## 3. Orchard copy of dataset
 
 - You need to move columns around and sort rows (see the Introduction).
-- The `all_of()` function may be useful for moving columns.
-- The `pick()` function might be useful for the sorting operation.
+- The [`all_of()`][ref-allof] function may be useful for moving columns.
+- The [`pick()`][ref-pick] function might be useful for the sorting operation.
 
 ## 4. Customer copy of dataset
 
 - You will need to take a subset of columns.
-- The `all_of()` function may be useful for subsetting.
+- The [`all_of()`][ref-allof] function may be useful for subsetting.
 - Only the trees between the minimum and maximum height *and* below the maximum weight should be in the copy.
+
+[ref-allof]: https://tidyselect.r-lib.org/reference/all_of.html
+[ref-pick]: https://dplyr.tidyverse.org/reference/pick.html

--- a/exercises/concept/trees-and-tibbleations/.docs/hints.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/hints.md
@@ -1,0 +1,25 @@
+# Hints
+
+## 1. Rename a column
+
+- Remember, you need to modify the `trees` dataset, which is available if `library(datasets)` is called.
+- You may (or may not) want to convert the initial `data.frame` into a `tibble`.
+- See the Introduction for how to change a column name.
+
+## 2. Add girth and weight columns
+
+- See the Introduction for how to add columns.
+- The new columns can be calculated with existing columns.
+- Don't forget to round to the required precision.
+
+## 3. Orchard copy of dataset
+
+- You need to move columns around and sort rows (see the Introduction).
+- The `all_of()` function may be useful for moving columns.
+- The `pick()` function might be useful for the sorting operation.
+
+## 4. Customer copy of dataset
+
+- You will need to take a subset of columns.
+- The `all_of()` function may be useful for subsetting.
+- Only the trees between the minimum and maximum height *and* below the maximum weight should be in the copy.

--- a/exercises/concept/trees-and-tibbleations/.docs/hints.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/hints.md
@@ -16,7 +16,8 @@
 
 - You need to move columns around and sort rows (see the Introduction).
 - The [`all_of()`][ref-allof] function may be useful for moving columns.
-- The [`pick()`][ref-pick] function might be useful for the sorting operation.
+- `arrange()` will silently fail if not given a proper column name (i.e. it doesn't like character strings)
+- `.data[[]]` or [`pick()`][ref-pick] might be useful for the sorting operation.
 
 ## 4. Customer copy of dataset
 

--- a/exercises/concept/trees-and-tibbleations/.docs/instructions.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/instructions.md
@@ -5,7 +5,7 @@ This helps keep the orchard healthy while providing extra revenue at the same ti
 They have asked you to help code up some functionality to help in the tree selection process when a potential customer calls.
 
 ~~~~exercism/note
-The built-in `datasets` library has many toy datasets, and this exercise uses the `trees` dataset.
+The built-in [`datasets`][ref-datasets] library has many toy datasets, and this exercise uses the `trees` dataset.
 To call the dataset after the library is loaded, simply use the name `trees`.
 ```R
 trees |> head(3)
@@ -19,6 +19,8 @@ trees |> head(3)
 Please note the three columns: `Girth`, `Height` and `Volume`
 
 The dataset is initially in the form of a `data.frame`, but you may want to choose to work with it as a `tibble`.
+
+[ref-datasets]: https://stat.ethz.ch/R-manual/R-devel/library/datasets/html/00Index.html
 ~~~~
 
 ## 1. Rename a column
@@ -29,7 +31,6 @@ Define a data.frame/tibble called `tree_data` that corrects the name of the `Gir
 
 ```R
 head(tree_data, 3)
-
 #>     A tibble: 3 × 3 
 #> Diameter	 Height	Volume
 #>    <dbl>	  <dbl>	 <dbl>
@@ -45,7 +46,7 @@ The girth is easily calculated by `πD`, where `D` is the diameter.
 The weight of all the timber can be calculate by `ρV`, where `ρ = 35` is the density of cherry wood and `V` is the volume of timber.
 
 Define the function `girth_n_weight(data, dgts)` which takes dataframe and numeric arguments.
-The function should return a new dataframe with the two additional columns: `Girth` and `Weight` rounded to the appropriate digits.
+The function should return a new dataframe with the two additional columns: `Girth` and `Weight` rounded to the appropriate number of digits.
 
 ```R
 girth_n_weight(tree_data, 1) |> head(3)
@@ -57,13 +58,15 @@ girth_n_weight(tree_data, 1) |> head(3)
 #>      8.8	     63	   10.2	  27.6	 357.0
 ```
 
+Note: For testing, the input dataset for `girth_n_weight` can be assumed to have `Diameter` and `Volume` columns.
+
 ## 3. Orchard copy of dataset
 
-The orchard keeps copy of the dataset which helps facilitate sales.
-This dataset has important columns moved to the front and sorted by that leading column.
+For each potential customer, the orchard keeps a special copy of the dataset to help with the sale.
+This dataset has important columns moved to the front and is sorted by that leading column.
 
 Define the function `orchard_copy(data, important_cols)` which takes a dataframe and a vector of column names.
-This should return a new dataframe with the columns in the order of the rearrangement and the rows sorted by the first column of that rearrangement.
+This should return a new dataframe with the important columns moved to the front and the rows sorted by the first column of that rearrangement.
 
 ```R
 orchard_copy(tree_data, c('Height', 'Volume')) |> head(3)
@@ -81,7 +84,7 @@ Each potential customer will get a personal version of the dataset based on thei
 To this end, the customer may specify two extra things:
 
 1. The minimum height, the maximum height and the maximum weight of any single tree.
-2. The full list of attributes that are of interest.
+2. A list of attributes that are of interest.
 
 Define the `customer_copy(data, attrbutes, min_height, max_height, max_weight)` function.
 Return a customer copy of the dataframe with the requested attributes and within the constraints.
@@ -99,3 +102,5 @@ tree_data |>
 #>     66	 546.0	  34.6
 #>     69	 745.5	  36.8
 ```
+
+Note: For testing, the input dataset for `customer_copy` can be assumed to have `Height` and `Weight` columns.

--- a/exercises/concept/trees-and-tibbleations/.docs/instructions.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/instructions.md
@@ -8,6 +8,8 @@ They have asked you to help code up some functionality to help in the tree selec
 The built-in [`datasets`][ref-datasets] library has many toy datasets, and this exercise uses the `trees` dataset.
 To call the dataset after the library is loaded, simply use the name `trees`.
 ```R
+library(datasets)
+
 trees |> head(3)
 #>    A data.frame: 3 × 3 	
 #>   Girth	Height	Volume
@@ -45,8 +47,8 @@ The girth (aka circumference) is still a useful measurement, and so is the weigh
 The girth is easily calculated by `πD`, where `D` is the diameter.
 The weight of all the timber can be calculate by `ρV`, where `ρ = 35` is the density of cherry wood and `V` is the volume of timber.
 
-Define the function `girth_n_weight(data, dgts)` which takes dataframe and numeric arguments.
-The function should return a new dataframe with the two additional columns: `Girth` and `Weight` rounded to the appropriate number of digits.
+Define the function `girth_n_weight(data, rnd_digits)` which takes dataframe and numeric arguments.
+The function should return a new dataframe with the two additional columns: `Girth` and `Weight` rounded to the appropriate number of digits given by `rnd_digits`.
 
 ```R
 girth_n_weight(tree_data, 1) |> head(3)

--- a/exercises/concept/trees-and-tibbleations/.docs/instructions.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/instructions.md
@@ -1,0 +1,101 @@
+# Instructions
+
+A large cherry orchard generally has a small inventory of surplus trees which they would like to offer as lumber.
+This helps keep the orchard healthy while providing extra revenue at the same time.
+They have asked you to help code up some functionality to help in the tree selection process when a potential customer calls.
+
+~~~~exercism/note
+The built-in `datasets` library has many toy datasets, and this exercise uses the `trees` dataset.
+To call the dataset after the library is loaded, simply use the name `trees`.
+```R
+trees |> head(3)
+#>    A data.frame: 3 × 3 	
+#>   Girth	Height	Volume
+#>	 <dbl>	 <dbl>	 <dbl>
+#> 1   8.3	    70	  10.3  
+#> 2   8.6	    65	  10.3
+#> 3   8.8	    63	  10.2
+```
+Please note the three columns: `Girth`, `Height` and `Volume`
+
+The dataset is initially in the form of a `data.frame`, but you may want to choose to work with it as a `tibble`.
+~~~~
+
+## 1. Rename a column
+
+Unfortunately there was a clerical error which has never been fixed and one column in the dataset is named `Girth`, but this is really the `Diameter`.
+
+Define a data.frame/tibble called `tree_data` that corrects the name of the `Girth` column in `trees` to `Diameter`.
+
+```R
+head(tree_data, 3)
+
+#>     A tibble: 3 × 3 
+#> Diameter	 Height	Volume
+#>    <dbl>	  <dbl>	 <dbl>
+#>      8.3	     70	  10.3
+#>      8.6	     65	  10.3
+#>      8.8	     63	  10.2
+```
+
+## 2. Add girth and weight columns
+
+The girth (aka circumference) is still a useful measurement, and so is the weight of the timber.
+The girth is easily calculated by `πD`, where `D` is the diameter.
+The weight of all the timber can be calculate by `ρV`, where `ρ = 35` is the density of cherry wood and `V` is the volume of timber.
+
+Define the function `girth_n_weight(data, dgts)` which takes dataframe and numeric arguments.
+The function should return a new dataframe with the two additional columns: `Girth` and `Weight` rounded to the appropriate digits.
+
+```R
+girth_n_weight(tree_data, 1) |> head(3)
+#>           A tibble: 3 × 5 
+#> Diameter  Height	 Volume	 Girth	Weight
+#>    <dbl>	  <dbl>	  <dbl>	 <dbl>	 <dbl>
+#>      8.3	     70	   10.3	  26.1	 360.5
+#>      8.6	     65	   10.3	  27.0	 360.5
+#>      8.8	     63	   10.2	  27.6	 357.0
+```
+
+## 3. Orchard copy of dataset
+
+The orchard keeps copy of the dataset which helps facilitate sales.
+This dataset has important columns moved to the front and sorted by that leading column.
+
+Define the function `orchard_copy(data, important_cols)` which takes a dataframe and a vector of column names.
+This should return a new dataframe with the columns in the order of the rearrangement and the rows sorted by the first column of that rearrangement.
+
+```R
+orchard_copy(tree_data, c('Height', 'Volume')) |> head(3)
+#>      A tibble: 3 × 3 
+#> Height	Volume	 Diameter
+#>  <dbl>	 <dbl>	    <dbl>
+#>     63	  10.2	      8.8
+#>     64	  24.9	     13.8
+#>     65	  10.3	      8.6
+```
+
+## 4. Customer copy of dataset
+
+Each potential customer will get a personal version of the dataset based on their preferences.
+To this end, the customer may specify two extra things:
+
+1. The minimum height, the maximum height and the maximum weight of any single tree.
+2. The full list of attributes that are of interest.
+
+Define the `customer_copy(data, attrbutes, min_height, max_height, max_weight)` function.
+Return a customer copy of the dataframe with the requested attributes and within the constraints.
+
+```R
+tree_data |> 
+    girth_n_weight(1) |> 
+    orchard_copy(c('Height', 'Weight', 'Volume')) |>
+    customer_copy(c('Height', 'Weight', 'Girth'), 65, 75, 1500) |> 
+    head(3)
+#>     A tibble: 3 × 3 
+#> Height	Weight   Girth
+#>  <dbl>	 <dbl>	 <dbl>
+#>     65	 360.5	  27.0
+#>     66	 546.0	  34.6
+#>     69	 745.5	  36.8
+```

--- a/exercises/concept/trees-and-tibbleations/.docs/introduction.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/introduction.md
@@ -306,8 +306,8 @@ tbl |> arrange(languages)
 ~~~~exercism/caution
 Many functions, such as `arrange()` and `mutate()` are data-masking and require data-masking variables.
 For this reason, non-data-masking arguments (e.g. character vectors) need to be converted to be used in data-masking functions.
+
 A full treatment of how data-masking works in R is beyond the scope of this concept, but it's useful to know there are ways of making this conversion which include options such as: `pick()`, `.data[[]]` and `!!sym()`.
-~~~~
 
 ```R
 tbl |> arrange("languages") # arrange with string input fails silently
@@ -328,3 +328,4 @@ tbl |> arrange(pick("languages"))
 #> 3 Python       1991 TRUE        
 #> 4 R            1993 TRUE     
 ```
+~~~~

--- a/exercises/concept/trees-and-tibbleations/.docs/introduction.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/introduction.md
@@ -1,0 +1,382 @@
+# Introduction
+
+In other parts of the syllabus, we have seen various data types with different characteristics.
+
+- Atomic vectors are 1-dimensional and homogenous in type.
+- Lists are 1-dimensional and elements can be of heterogenous types.
+- Matrices and arrays are multi-dimensional and homogeneous.
+
+This Concept will look at ways to store multi-dimensional, heterogenous data.
+In practice, _most_ real-world data is like this, so we are now getting to the heart of how R is (mostly) used in practice.
+
+## Dataframe variants
+
+Over the decades, R has added multiple data types to handle tabular data.
+
+This syllabus will focus mainly on tibbles, but it is useful to know about alternatives.
+
+### The `data.frame`
+
+In Base R, a `data.frame` is a `list` of equal-length `vectors`.
+This can be thought of as a rectangular table of data, in which each column is homogeneous, but each row can (and usually does) contain different types of data.
+
+An example to illustrate this:
+
+```R
+# create the column vectors
+languages <- c("Fortran", "R", "Python", "Julia")
+created <- c(1957, 1993, 1991, 2012)
+has.syllabus <- c(FALSE, TRUE, TRUE, TRUE)
+
+# join columns to create the dataframe
+df <- data.frame(languages, created, has.syllabus)
+df
+#>   languages created has.syllabus
+#> 1   Fortran    1957        FALSE
+#> 2         R    1993         TRUE
+#> 3    Python    1991         TRUE
+#> 4     Julia    2012         TRUE
+
+# look at the structure
+str(df)
+#> 'data.frame':	4 obs. of  3 variables:
+ #> $ languages   : chr  "Fortran" "R" "Python" "Julia"
+ #> $ created     : num  1957 1993 1991 2012
+ #> $ has.syllabus: logi  FALSE TRUE TRUE TRUE
+ ```
+
+ We have a column of character strings, a column of numbers and a column of booleans.
+ When scaled up, this is an intuitive way to represent many collections of real world data.
+
+### The `tibble`
+
+The `data.frame` design is _old_.
+
+Multi-decade experience, plus changing patterns of how R is used, led to a redesign, creating a modernized alternative in the Tidyverse: tibbles.
+
+Compared to Base R, tibbles have:
+
+- Different defaults, to reduce common problems.
+- Less willingness to coerce data types during input.
+- More and clearer error messages.
+- Different, usually better, display formats.
+
+In short, a `tibble` aims to "_do less and complain more_", also described as "_lazy and surly_".
+
+The types are usually interchangeable: any function which accepts a `data.frame` will also accept a `tibble`, and _vice versa_.
+
+Conversions between the types are easy, with `as_tibble(df)` and `as.data.frame(tbl)`.
+
+For new work, using tibbles will probably help you create more robust code.
+However, legacy code and legacy data is very plentiful in the R world, so the `data.frame` is likely to remain common for a long time.
+
+```R
+# column vectors are same as for data.frame
+library(tibble)
+tbl <- tibble(languages, created, has.syllabus)
+tbl
+  # A tibble: 4 × 3
+#>   languages created has.syllabus
+#>   <chr>       <dbl> <lgl>       
+#> 1 Fortran      1957 FALSE       
+#> 2 R            1993 TRUE        
+#> 3 Python       1991 TRUE        
+#> 4 Julia        2012 TRUE      
+  
+str(tbl)
+#> tibble [4 × 3] (S3: tbl_df/tbl/data.frame)
+#>  $ languages   : chr [1:4] "Fortran" "R" "Python" "Julia"
+#>  $ created     : num [1:4] 1957 1993 1991 2012
+#>  $ has.syllabus: logi [1:4] FALSE TRUE TRUE TRUE
+```
+
+Note the default print format: the comment line with dimensions is printed automatically, and column types are also displayed.
+
+## Working with tibbles
+
+Tibbles are a core part of the Tidyverse, so add them with either `library(tibble)` or `library(tidyverse)`.
+
+### Creating a tibble
+
+Most simply, we can use the `tibble()` function to join column vectors, as for `data.frame()`.
+An example of this was shown in a previous section.
+
+If it is more convenient to enter values row-wise, the corresponding function is `tribble()`.
+
+```R
+tbl_r <- tribble(
+  # column names marked with tilde prefix
+  ~languages, ~created, ~has.syllabus,
+  "Fortran", 1957, FALSE,
+  "R", 1993, TRUE,
+  "Python", 1991, TRUE,
+  "Julia", 2012, TRUE
+)
+
+tbl_r
+# A tibble: 4 × 3
+#>   languages created has.syllabus
+#>   <chr>       <dbl> <lgl>       
+#> 1 Fortran      1957 FALSE       
+#> 2 R            1993 TRUE        
+#> 3 Python       1991 TRUE        
+#> 4 Julia        2012 TRUE    
+```
+
+In practice, there are dozens of ways to create tibbles, as they are the default output format from a diverse range of Tidyverse functions.
+We will return to this in a future Concept.
+
+## Manipulating a tibble
+
+The Functional Programming Concept discussed the `purrr` library to manipulate vectors and lists (1-D data structures).
+
+For dataframes (whether traditional or tibbles), the corresponding library to use is `dplyr`.
+
+### Subsetting
+
+Dataframes, including tibbles, can be treated as lists of column vectors, so list indexing recovers a specified column.
+
+```R
+tbl
+# A tibble: 4 × 3
+#>   languages created has.syllabus
+#>   <chr>       <dbl> <lgl>       
+#> 1 Fortran      1957 FALSE       T ar
+#> 2 R            1993 TRUE        
+#> 3 Python       1991 TRUE        
+#> 4 Julia        2012 TRUE    
+
+tbl$created
+#> [1] 1957 1993 1991 2012
+```
+
+A dataframe can also be indexed with matrix-style indexing.
+
+```R
+tbl[c(2, 4), 1:2]
+  # A tibble: 2 × 2
+#>   languages created
+#>   <chr>       <dbl>
+#> 1 R            1993
+#> 2 Julia        2012
+```
+
+In modern R with the Tidyverse ecosystem, `dplyr` functions are generally more flexible and convenient, and will be the focus for the rest of this Concept.
+
+### Column-wise operations
+
+Get a single column with `pull()` with the name or sequential number (negative numbers to count right-to-left).
+
+```R
+tbl |> pull(created)
+#> [1] 1957 1993 1991 2012
+```
+
+This is the same result as `tbl$created`, but using a pipeline-friendly function.
+
+To get multiple columns, the appropriate function is `select()`, which is highly versatile.
+Get (or drop) columns based on properties of their name or type.
+
+```R
+# Range with position and/or name
+tbl |> select(1:created)
+  # A tibble: 4 × 2
+#>   languages created
+#>   <chr>       <dbl>
+#> 1 Fortran      1957
+#> 2 R            1993
+#> 3 Python       1991
+#> 4 Julia        2012
+
+# Exclude a column
+tbl |> select(!created)
+  # A tibble: 4 × 2
+#>   languages has.syllabus
+#>   <chr>     <lgl>       
+#> 1 Fortran   FALSE       
+#> 2 R         TRUE        
+#> 3 Python    TRUE        
+#> 4 Julia     TRUE        
+
+# Use type of column
+tbl |> select(where(is.numeric))
+  # A tibble: 4 × 1
+#>   created
+#>     <dbl>
+#> 1    1957
+#> 2    1993
+#> 3    1991
+#> 4    2012
+```
+
+Multiple criteria are allowed, using Boolean operators `&`, `|` and `!` (and, or not).
+
+Column names that are _valid R identifiers_ do not need quotes within a `select()`.
+Invalid names (e.g. those including spaces) can be enclosed in backticks, though renaming them might be better.
+
+The `select()` function can work with a range of helper functions to pick column names: `starts_with`, `contains`, `num_range` and various others.
+`matches` allows full RegEx matching.
+See the documentation for details.
+
+Such power seems quite silly with our toy dataframe of languages.
+Fortunately, the `starwars` tibble is included in `dplyr`, giving us something bigger to practice with.
+
+```R
+# limit display to top 3 rows of non-list columns
+starwars |> 
+  select(!where(is.list)) |> 
+  head(3)
+  # A tibble: 3 × 11
+#>   name           height  mass hair_color skin_color  eye_color birth_year sex   gender    homeworld species
+#>   <chr>           <int> <dbl> <chr>      <chr>       <chr>          <dbl> <chr> <chr>     <chr>     <chr>  
+#> 1 Luke Skywalker    172    77 blond      fair        blue              19 male  masculine Tatooine  Human  
+#> 2 C-3PO             167    75 NA         gold        yellow           112 none  masculine Tatooine  Droid  
+#> 3 R2-D2              96    32 NA         white, blue red               33 none  masculine Naboo     Droid  
+
+# pick a subset of columns
+starwars |> 
+  select(name | ends_with("color")) |> 
+  head(5)
+  # A tibble: 5 × 4
+#>   name           hair_color skin_color  eye_color
+#>   <chr>          <chr>      <chr>       <chr>    
+#> 1 Luke Skywalker blond      fair        blue     
+#> 2 C-3PO          NA         gold        yellow   
+#> 3 R2-D2          NA         white, blue red      
+#> 4 Darth Vader    none       white       yellow   
+#> 5 Leia Organa    brown      light       brown    
+```
+
+### Row-wise operations
+
+Get rows matching some criteria with `filter()`, or exclude them with `filter_out()`.
+
+```R
+starwars |> 
+  select(name:mass) |> 
+  filter(between(height, 150, 165) & !is.na(mass))
+  # A tibble: 4 × 3
+#>   name               height  mass
+#>   <chr>               <int> <dbl>
+#> 1 Leia Organa           150    49
+#> 2 Beru Whitesun Lars    165    75
+#> 3 Nien Nunb             160    68
+#> 4 Ben Quadinaros        163    65
+```
+
+Filter criteria can be arbitrarily complex, but always based on row _contents_.
+
+If row _numbers_ are known, we can use a variety of `slice()` functions.
+
+```R
+starwars |> 
+  select(name | homeworld) |> 
+  slice(20:25)
+  # A tibble: 6 × 2
+#>   name             homeworld
+#>   <chr>            <chr>    
+#> 1 Palpatine        Naboo    
+#> 2 Boba Fett        Kamino   
+#> 3 IG-88            NA       
+#> 4 Bossk            Trandosha
+#> 5 Lando Calrissian Socorro  
+#> 6 Lobot            Bespin   
+
+# random sample of rows
+starwars |> 
+  select(name | homeworld) |> 
+  slice_sample(n = 4)
+  # A tibble: 4 × 2
+#>   name            homeworld
+#>   <chr>           <chr>    
+#> 1 Shaak Ti        Shili    
+#> 2 Luminara Unduli Mirial   
+#> 3 Grievous        Kalee    
+#> 4 Palpatine       Naboo    
+```
+
+To remove duplicate rows, use `distinct()`.
+
+## Modifying a tibble
+
+First caveat: the _copy-on-modify_ default means that the original tibble usually remains unchanged.
+
+Most modifications are applied column-wise.
+
+Column names can be changed with `rename(newname = oldname)`, or `rename_with()` to apply a function.
+A typical use would be cleaning up imported names to make them easier to work with in R, by removing whitespace and forcing a consistent format for related names.
+
+Note the syntax within `rename()`.
+The _contents_ of column `oldname` are _bound_ to name `newname`, hence the order.
+
+Column order can be changed with `relocate()`.
+Specified column(s) are moved to the left-most position(s) by default, but a `.before` or `.after` argument can be used for finer positioning.
+
+```R
+sw <- starwars |> select(name:species) |> slice(1:4)
+sw
+  # A tibble: 4 × 11
+#>   name           height  mass hair_color skin_color  eye_color birth_year sex   gender    homeworld species
+#>   <chr>           <int> <dbl> <chr>      <chr>       <chr>          <dbl> <chr> <chr>     <chr>     <chr>  
+#> 1 Luke Skywalker    172    77 blond      fair        blue            19   male  masculine Tatooine  Human  
+#> 2 C-3PO             167    75 NA         gold        yellow         112   none  masculine Tatooine  Droid  
+#> 3 R2-D2              96    32 NA         white, blue red             33   none  masculine Naboo     Droid  
+#> 4 Darth Vader       202   136 none       white       yellow          41.9 male  masculine Tatooine  Human  
+
+sw |> relocate(c(species, homeworld), .after = name)
+  # A tibble: 4 × 11
+#>   name           species homeworld height  mass hair_color skin_color  eye_color birth_year sex   gender   
+#>   <chr>          <chr>   <chr>      <int> <dbl> <chr>      <chr>       <chr>          <dbl> <chr> <chr>    
+#> 1 Luke Skywalker Human   Tatooine     172    77 blond      fair        blue            19   male  masculine
+#> 2 C-3PO          Droid   Tatooine     167    75 NA         gold        yellow         112   none  masculine
+#> 3 R2-D2          Droid   Naboo         96    32 NA         white, blue red             33   none  masculine
+#> 4 Darth Vader    Human   Tatooine     202   136 none       white       yellow          41.9 male  masculine
+```
+
+For bigger changes, `mutate()` lets you:
+
+- Create new columns that are functions of existing columns.
+- Replace an existing column, by creating a new column with the same name.
+- Delete a column, by setting its value to `NULL`.
+
+Clearly, `mutate()` is powerful, potentially confusing, and a reason to be very grateful for copy-on-modify.
+
+There is no obvious reason to care about the Body Mass Index of Star Wars characters, but just in case:
+
+```R
+starwars |> 
+  select(c(name, species, height, mass)) |> 
+  mutate(BMI = mass / (height / 100)^2) |> 
+  head(4)
+  # A tibble: 4 × 5
+#>   name           species height  mass   BMI
+#>   <chr>          <chr>    <int> <dbl> <dbl>
+#> 1 Luke Skywalker Human      172    77  26.0
+#> 2 C-3PO          Droid      167    75  26.9
+#> 3 R2-D2          Droid       96    32  34.7
+#> 4 Darth Vader    Human      202   136  33.3
+```
+
+Row-wise operations are less common for modifying single tibbles (merging multiple tibbles will be discussed in a later concept).
+
+One exception: `arrange()` sorts rows by the values in one or more columns.
+
+```R
+tbl
+  # A tibble: 4 × 3
+#>   languages created has.syllabus
+#>   <chr>       <dbl> <lgl>       
+#> 1 Fortran      1957 FALSE       
+#> 2 R            1993 TRUE        
+#> 3 Python       1991 TRUE        
+#> 4 Julia        2012 TRUE  
+
+tbl |> arrange(languages)
+  # A tibble: 4 × 3
+#>   languages created has.syllabus
+#>   <chr>       <dbl> <lgl>       
+#> 1 Fortran      1957 FALSE       
+#> 2 Julia        2012 TRUE        
+#> 3 Python       1991 TRUE        
+#> 4 R            1993 TRUE     
+```

--- a/exercises/concept/trees-and-tibbleations/.docs/introduction.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/introduction.md
@@ -36,13 +36,6 @@ df
 #> 2         R    1993         TRUE
 #> 3    Python    1991         TRUE
 #> 4     Julia    2012         TRUE
-
-# look at the structure
-str(df)
-#> 'data.frame':	4 obs. of  3 variables:
- #> $ languages   : chr  "Fortran" "R" "Python" "Julia"
- #> $ created     : num  1957 1993 1991 2012
- #> $ has.syllabus: logi  FALSE TRUE TRUE TRUE
  ```
 
  We have a column of character strings, a column of numbers and a column of booleans.
@@ -82,12 +75,6 @@ tbl
 #> 2 R            1993 TRUE        
 #> 3 Python       1991 TRUE        
 #> 4 Julia        2012 TRUE      
-  
-str(tbl)
-#> tibble [4 × 3] (S3: tbl_df/tbl/data.frame)
-#>  $ languages   : chr [1:4] "Fortran" "R" "Python" "Julia"
-#>  $ created     : num [1:4] 1957 1993 1991 2012
-#>  $ has.syllabus: logi [1:4] FALSE TRUE TRUE TRUE
 ```
 
 Note the default print format: the comment line with dimensions is printed automatically, and column types are also displayed.
@@ -103,28 +90,7 @@ An example of this was shown in a previous section.
 
 If it is more convenient to enter values row-wise, the corresponding function is `tribble()`.
 
-```R
-tbl_r <- tribble(
-  # column names marked with tilde prefix
-  ~languages, ~created, ~has.syllabus,
-  "Fortran", 1957, FALSE,
-  "R", 1993, TRUE,
-  "Python", 1991, TRUE,
-  "Julia", 2012, TRUE
-)
-
-tbl_r
-# A tibble: 4 × 3
-#>   languages created has.syllabus
-#>   <chr>       <dbl> <lgl>       
-#> 1 Fortran      1957 FALSE       
-#> 2 R            1993 TRUE        
-#> 3 Python       1991 TRUE        
-#> 4 Julia        2012 TRUE    
-```
-
 In practice, there are dozens of ways to create tibbles, as they are the default output format from a diverse range of Tidyverse functions.
-We will return to this in a future Concept.
 
 ## Manipulating a tibble
 
@@ -141,7 +107,7 @@ tbl
 # A tibble: 4 × 3
 #>   languages created has.syllabus
 #>   <chr>       <dbl> <lgl>       
-#> 1 Fortran      1957 FALSE       T ar
+#> 1 Fortran      1957 FALSE       
 #> 2 R            1993 TRUE        
 #> 3 Python       1991 TRUE        
 #> 4 Julia        2012 TRUE    
@@ -186,17 +152,7 @@ tbl |> select(1:created)
 #> 1 Fortran      1957
 #> 2 R            1993
 #> 3 Python       1991
-#> 4 Julia        2012
-
-# Exclude a column
-tbl |> select(!created)
-  # A tibble: 4 × 2
-#>   languages has.syllabus
-#>   <chr>     <lgl>       
-#> 1 Fortran   FALSE       
-#> 2 R         TRUE        
-#> 3 Python    TRUE        
-#> 4 Julia     TRUE        
+#> 4 Julia        2012      
 
 # Use type of column
 tbl |> select(where(is.numeric))
@@ -211,28 +167,10 @@ tbl |> select(where(is.numeric))
 
 Multiple criteria are allowed, using Boolean operators `&`, `|` and `!` (and, or not).
 
-Column names that are _valid R identifiers_ do not need quotes within a `select()`.
-Invalid names (e.g. those including spaces) can be enclosed in backticks, though renaming them might be better.
-
-The `select()` function can work with a range of helper functions to pick column names: `starts_with`, `contains`, `num_range` and various others.
-`matches` allows full RegEx matching.
-See the documentation for details.
-
 Such power seems quite silly with our toy dataframe of languages.
 Fortunately, the `starwars` tibble is included in `dplyr`, giving us something bigger to practice with.
 
 ```R
-# limit display to top 3 rows of non-list columns
-starwars |> 
-  select(!where(is.list)) |> 
-  head(3)
-  # A tibble: 3 × 11
-#>   name           height  mass hair_color skin_color  eye_color birth_year sex   gender    homeworld species
-#>   <chr>           <int> <dbl> <chr>      <chr>       <chr>          <dbl> <chr> <chr>     <chr>     <chr>  
-#> 1 Luke Skywalker    172    77 blond      fair        blue              19 male  masculine Tatooine  Human  
-#> 2 C-3PO             167    75 NA         gold        yellow           112 none  masculine Tatooine  Droid  
-#> 3 R2-D2              96    32 NA         white, blue red               33 none  masculine Naboo     Droid  
-
 # pick a subset of columns
 starwars |> 
   select(name | ends_with("color")) |> 
@@ -281,21 +219,7 @@ starwars |>
 #> 4 Bossk            Trandosha
 #> 5 Lando Calrissian Socorro  
 #> 6 Lobot            Bespin   
-
-# random sample of rows
-starwars |> 
-  select(name | homeworld) |> 
-  slice_sample(n = 4)
-  # A tibble: 4 × 2
-#>   name            homeworld
-#>   <chr>           <chr>    
-#> 1 Shaak Ti        Shili    
-#> 2 Luminara Unduli Mirial   
-#> 3 Grievous        Kalee    
-#> 4 Palpatine       Naboo    
 ```
-
-To remove duplicate rows, use `distinct()`.
 
 ## Modifying a tibble
 
@@ -304,8 +228,6 @@ First caveat: the _copy-on-modify_ default means that the original tibble usuall
 Most modifications are applied column-wise.
 
 Column names can be changed with `rename(newname = oldname)`, or `rename_with()` to apply a function.
-A typical use would be cleaning up imported names to make them easier to work with in R, by removing whitespace and forcing a consistent format for related names.
-
 Note the syntax within `rename()`.
 The _contents_ of column `oldname` are _bound_ to name `newname`, hence the order.
 

--- a/exercises/concept/trees-and-tibbleations/.docs/introduction.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/introduction.md
@@ -278,24 +278,6 @@ starwars |>
 #> 3 R2-D2          Droid       96    32  34.7
 #> 4 Darth Vader    Human      202   136  33.3
 ```
-When you want to operate on a subset of the columns with functions such as `mutate()`, the `select() |> mutate()` sequence in the above example is one option.
-Only the selected columns will be in the result.
-
-Alternatively, it can be convenient to use `pick()` _within_ the `mutate()` call:
-
-```R
-starwars |> mutate(pick(c(height, mass)), BMI = mass / (height / 100)^2) |> head(4)
-#>                                                A tibble: 4 × 15
-#>         name  height  mass hair_color skin_color eye_color birth_year   sex  gender homeworld species films vehicles
-#>        <chr>   <int> <dbl>      <chr>      <chr>     <chr>      <dbl> <chr>   <chr>     <chr>   <chr> <lis>   <list>  
-#> Luke Skywal…     172    77      blond       fair      blue         19  male  mascu…  Tatooine   Human <chr>    <chr>   
-#>        C-3PO     167    75         NA       gold    yellow        112  none  mascu…  Tatooine   Droid <chr>    <chr>   
-#>        R2-D2      96    32         NA white, bl…       red         33  none  mascu…     Naboo   Droid <chr>    <chr>   
-#>  Darth Vader     202   136       none      white    yellow       41.9  male  mascu…  Tatooine   Human <chr>    <chr>   
-#> # ℹ 2 more variables: starships <list>, BMI <dbl>
-```
-
-Only the `pick`ed columns are used in the mutation, but all columns are returned.
 
 **Row-wise operations** are less common for modifying single tibbles (merging multiple tibbles will be discussed in a later concept).
 
@@ -303,7 +285,7 @@ One exception: `arrange()` sorts rows by the values in one or more columns.
 
 ```R
 tbl
-  # A tibble: 4 × 3
+#>       A tibble: 4 × 3
 #>   languages created has.syllabus
 #>   <chr>       <dbl> <lgl>       
 #> 1 Fortran      1957 FALSE       
@@ -312,7 +294,33 @@ tbl
 #> 4 Julia        2012 TRUE  
 
 tbl |> arrange(languages)
-  # A tibble: 4 × 3
+#>       A tibble: 4 × 3
+#>   languages created has.syllabus
+#>   <chr>       <dbl> <lgl>       
+#> 1 Fortran      1957 FALSE       
+#> 2 Julia        2012 TRUE        
+#> 3 Python       1991 TRUE        
+#> 4 R            1993 TRUE     
+```
+
+~~~~exercism/caution
+Many functions, such as `arrange()` and `mutate()` are data-masking and require data-masking variables.
+For this reason, non-data-masking arguments (e.g. character vectors) need to be converted to be used in data-masking functions.
+A full treatment of how data-masking works in R is beyond the scope of this concept, but it's useful to know there are ways of making this conversion which include options such as: `pick()`, `.data[[]]` and `!!sym()`.
+~~~~
+
+```R
+tbl |> arrange("languages") # arrange with string input fails silently
+#>      A tibble: 4 × 3
+#>   languages created has.syllabus
+#>   <chr>       <dbl> <lgl>       
+#> 1 Fortran      1957 FALSE       
+#> 2 R            1993 TRUE        
+#> 3 Python       1991 TRUE        
+#> 4 Julia        2012 TRUE 
+
+tbl |> arrange(pick("languages"))
+#>       A tibble: 4 × 3
 #>   languages created has.syllabus
 #>   <chr>       <dbl> <lgl>       
 #> 1 Fortran      1957 FALSE       

--- a/exercises/concept/trees-and-tibbleations/.docs/introduction.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/introduction.md
@@ -304,7 +304,7 @@ tbl |> arrange(languages)
 ```
 
 ~~~~exercism/caution
-Many functions, such as `arrange()` and `mutate()` are data-masking and require data-masking variables.
+Many functions, such as `arrange()`, `filter()` and `mutate()` are data-masking and require data-masking variables.
 For this reason, non-data-masking arguments (e.g. character vectors) need to be converted to be used in data-masking functions.
 
 A full treatment of how data-masking works in R is beyond the scope of this concept, but it's useful to know there are ways of making this conversion which include options such as: `pick()`, `.data[[]]` and `!!sym()`.

--- a/exercises/concept/trees-and-tibbleations/.docs/introduction.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/introduction.md
@@ -281,18 +281,18 @@ starwars |>
 When you want to operate on a subset of the columns with functions such as `mutate()`, the `select() |> mutate()` sequence in the above example is one option.
 Only the selected columns will be in the result.
 
-Alternatively, it can be convenient to use [`pick()`][ref-pick] _within_ the `mutate()` call:
+Alternatively, it can be convenient to use `pick()` _within_ the `mutate()` call:
 
 ```R
-starwars |> mutate(pick(c(name, species, height, mass)), BMI = mass / (height / 100)^2) |> head(4)
-# A tibble: 4 × 15
-  name         height  mass hair_color skin_color eye_color birth_year sex   gender homeworld species films vehicles
-  <chr>         <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr>  <chr>     <chr>   <lis> <list>  
-1 Luke Skywal…    172    77 blond      fair       blue            19   male  mascu… Tatooine  Human   <chr> <chr>   
-2 C-3PO           167    75 NA         gold       yellow         112   none  mascu… Tatooine  Droid   <chr> <chr>   
-3 R2-D2            96    32 NA         white, bl… red             33   none  mascu… Naboo     Droid   <chr> <chr>   
-4 Darth Vader     202   136 none       white      yellow          41.9 male  mascu… Tatooine  Human   <chr> <chr>   
-# ℹ 2 more variables: starships <list>, BMI <dbl>
+starwars |> mutate(pick(c(height, mass)), BMI = mass / (height / 100)^2) |> head(4)
+#>                                                A tibble: 4 × 15
+#>         name  height  mass hair_color skin_color eye_color birth_year   sex  gender homeworld species films vehicles
+#>        <chr>   <int> <dbl>      <chr>      <chr>     <chr>      <dbl> <chr>   <chr>     <chr>   <chr> <lis>   <list>  
+#> Luke Skywal…     172    77      blond       fair      blue         19  male  mascu…  Tatooine   Human <chr>    <chr>   
+#>        C-3PO     167    75         NA       gold    yellow        112  none  mascu…  Tatooine   Droid <chr>    <chr>   
+#>        R2-D2      96    32         NA white, bl…       red         33  none  mascu…     Naboo   Droid <chr>    <chr>   
+#>  Darth Vader     202   136       none      white    yellow       41.9  male  mascu…  Tatooine   Human <chr>    <chr>   
+#> # ℹ 2 more variables: starships <list>, BMI <dbl>
 ```
 
 Only the `pick`ed columns are used in the mutation, but all columns are returned.

--- a/exercises/concept/trees-and-tibbleations/.docs/introduction.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/introduction.md
@@ -278,8 +278,26 @@ starwars |>
 #> 3 R2-D2          Droid       96    32  34.7
 #> 4 Darth Vader    Human      202   136  33.3
 ```
+When you want to operate on a subset of the columns with functions such as `mutate()`, the `select() |> mutate()` sequence in the above example is one option.
+Only the selected columns will be in the result.
 
-Row-wise operations are less common for modifying single tibbles (merging multiple tibbles will be discussed in a later concept).
+Alternatively, it can be convenient to use [`pick()`][ref-pick] _within_ the `mutate()` call:
+
+```R
+starwars |> mutate(pick(c(name, species, height, mass)), BMI = mass / (height / 100)^2) |> head(4)
+# A tibble: 4 × 15
+  name         height  mass hair_color skin_color eye_color birth_year sex   gender homeworld species films vehicles
+  <chr>         <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr>  <chr>     <chr>   <lis> <list>  
+1 Luke Skywal…    172    77 blond      fair       blue            19   male  mascu… Tatooine  Human   <chr> <chr>   
+2 C-3PO           167    75 NA         gold       yellow         112   none  mascu… Tatooine  Droid   <chr> <chr>   
+3 R2-D2            96    32 NA         white, bl… red             33   none  mascu… Naboo     Droid   <chr> <chr>   
+4 Darth Vader     202   136 none       white      yellow          41.9 male  mascu… Tatooine  Human   <chr> <chr>   
+# ℹ 2 more variables: starships <list>, BMI <dbl>
+```
+
+Only the `pick`ed columns are used in the mutation, but all columns are returned.
+
+**Row-wise operations** are less common for modifying single tibbles (merging multiple tibbles will be discussed in a later concept).
 
 One exception: `arrange()` sorts rows by the values in one or more columns.
 

--- a/exercises/concept/trees-and-tibbleations/.meta/config.json
+++ b/exercises/concept/trees-and-tibbleations/.meta/config.json
@@ -13,5 +13,5 @@
       ".meta/exemplar.R"
     ]
   },
-  "blurb": "Learn about dataframes by helping a lumber operation wrangle some data"
+  "blurb": "Learn about dataframes by helping a cherry orchard wrangle some data"
 }

--- a/exercises/concept/trees-and-tibbleations/.meta/config.json
+++ b/exercises/concept/trees-and-tibbleations/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [
+    "depial"
+  ],
+  "files": {
+    "solution": [
+      "trees-and-tibbleations.R"
+    ],
+    "test": [
+      "test_trees-and-tibbleations.R"
+    ],
+    "exemplar": [
+      ".meta/exemplar.R"
+    ]
+  },
+  "blurb": "Learn about dataframes by helping a lumber operation wrangle some data"
+}

--- a/exercises/concept/trees-and-tibbleations/.meta/design.md
+++ b/exercises/concept/trees-and-tibbleations/.meta/design.md
@@ -1,0 +1,27 @@
+# Design
+
+## Goal
+
+The goal of this exercise is to teach the student how to use dataframes with the `dplyr` library.
+
+## Learning objectives
+
+- Understand that there are different kinds of dataframes: `data.frame`, `tibble`, `data.table`.
+- Understand basic columnwise and rowwise operations: `mutate`, `arrange`, etc.
+- Understand how to move / subset: `relocate`, `select`, `filter`.
+
+## Out of scope
+
+- Merging dataframes
+- Dimension collapsing operations
+- Data operations / data analysis
+
+## Concepts
+
+The Concepts this exercise unlocks are:
+
+- `factors`
+
+## Prerequisites
+
+- `functional-programming`

--- a/exercises/concept/trees-and-tibbleations/.meta/exemplar.R
+++ b/exercises/concept/trees-and-tibbleations/.meta/exemplar.R
@@ -3,10 +3,10 @@ library(tidyverse)
 
 tree_data <- trees |> as_tibble() |> rename(Diameter = Girth)
 
-girth_n_weight <- function(data, dgts) {
+girth_n_weight <- function(data, rnd_digits) {
   data |>
     mutate(Girth = pi * Diameter, Weight = 35 * Volume) |>
-    round(dgts)
+    round(rnd_digits)
 }
 
 orchard_copy <- function(data, important_cols) {

--- a/exercises/concept/trees-and-tibbleations/.meta/exemplar.R
+++ b/exercises/concept/trees-and-tibbleations/.meta/exemplar.R
@@ -3,7 +3,7 @@ library(tidyverse)
 
 tree_data <- trees |> as_tibble() |> rename(Diameter = Girth)
 
-girth_n_weight <- function(data, dgts=1) {
+girth_n_weight <- function(data, dgts) {
   data |>
     mutate(Girth = pi * Diameter, Weight = 35 * Volume) |>
     round(dgts)

--- a/exercises/concept/trees-and-tibbleations/.meta/exemplar.R
+++ b/exercises/concept/trees-and-tibbleations/.meta/exemplar.R
@@ -1,0 +1,22 @@
+library(datasets)
+library(tidyverse)
+
+tree_data <- trees |> as_tibble() |> rename(Diameter = Girth)
+
+girth_n_weight <- function(data, dgts=1) {
+  data |>
+    mutate(Girth = pi * Diameter, Weight = 35 * Volume) |>
+    round(dgts)
+}
+
+orchard_copy <- function(data, important_cols) {
+  data |>
+    relocate(all_of(important_cols)) |>
+    arrange(pick(important_cols[1]))
+}
+
+customer_copy <- function(data, attributes, min_height, max_height, max_weight) {
+  data |> 
+    select(all_of(attributes)) |>
+    filter(between(Height, min_height, max_height) & Weight < max_weight)
+}

--- a/exercises/concept/trees-and-tibbleations/test_trees-and-tibbleations.R
+++ b/exercises/concept/trees-and-tibbleations/test_trees-and-tibbleations.R
@@ -1,0 +1,36 @@
+source("./trees-and-tibbleations.R")
+library(testthat)
+
+test_that("1. Rename a column", {
+  expect_setequal(names(tree_data), c('Diameter', 'Height', 'Volume'))
+  expect_equal(tree_data$Diameter[7:11], c(11, 11, 11.1, 11.2, 11.3))
+})
+
+
+test_that("2. Add girth and weight columns", {
+  test_data <- girth_n_weight(tree_data, 1)
+    
+  expect_true('Girth' %in% names(test_data))
+  expect_equal(test_data$Girth[21:24], c(44, 44.6, 45.6, 50.3))
+
+  expect_true('Weight' %in% names(test_data))
+  expect_equal(test_data$Weight[29:31], c(1802.5, 1785.0, 2695.0))
+})
+
+test_that("3. Orchard copy of dataset", {
+  test_data <- tree_data |> girth_n_weight(1) |> orchard_copy(c('Height', 'Weight'))
+    
+  expect_setequal(names(test_data), c('Height', 'Weight', 'Diameter', 'Volume', 'Girth'))
+  expect_equal(names(test_data)[1:2], c('Height', 'Weight'))
+  expect_equal(test_data$Height[15:18], c(76, 76, 77, 78))
+  expect_equal(test_data$Girth[21:24], c(44.6, 56.2, 56.5, 56.5))
+  expect_equal(test_data$Weight[5:9], c(745.5, 360.5, 899.5, 574.0, 1340.5))
+})
+
+test_that("3. Customer copy of dataset", {
+  test_data <- tree_data |> girth_n_weight(1) |> customer_copy(c('Weight', 'Height', 'Girth'), 70, 75, 1000)
+  expect_equal(names(test_data), c('Weight', 'Height', 'Girth'))
+  expect_equal(test_data$Weight[2:5], c(574.0, 637.0, 696.5, 668.5))
+  expect_equal(test_data$Height[4:7], c(75, 75, 74, 71))
+  expect_equal(test_data$Girth[1:4], c(26.1, 33.0, 34.6, 35.2))
+})

--- a/exercises/concept/trees-and-tibbleations/test_trees-and-tibbleations.R
+++ b/exercises/concept/trees-and-tibbleations/test_trees-and-tibbleations.R
@@ -6,20 +6,18 @@ test_that("1. Rename a column", {
   expect_equal(tree_data$Diameter[7:11], c(11, 11, 11.1, 11.2, 11.3))
 })
 
-
 test_that("2. Add girth and weight columns", {
   test_data <- girth_n_weight(tree_data, 1)
-    
+
   expect_true('Girth' %in% names(test_data))
   expect_equal(test_data$Girth[21:24], c(44, 44.6, 45.6, 50.3))
-
   expect_true('Weight' %in% names(test_data))
   expect_equal(test_data$Weight[29:31], c(1802.5, 1785.0, 2695.0))
 })
 
 test_that("3. Orchard copy of dataset", {
   test_data <- tree_data |> girth_n_weight(1) |> orchard_copy(c('Height', 'Weight'))
-    
+
   expect_setequal(names(test_data), c('Height', 'Weight', 'Diameter', 'Volume', 'Girth'))
   expect_equal(names(test_data)[1:2], c('Height', 'Weight'))
   expect_equal(test_data$Height[15:18], c(76, 76, 77, 78))
@@ -29,6 +27,7 @@ test_that("3. Orchard copy of dataset", {
 
 test_that("3. Customer copy of dataset", {
   test_data <- tree_data |> girth_n_weight(1) |> customer_copy(c('Weight', 'Height', 'Girth'), 70, 75, 1000)
+
   expect_equal(names(test_data), c('Weight', 'Height', 'Girth'))
   expect_equal(test_data$Weight[2:5], c(574.0, 637.0, 696.5, 668.5))
   expect_equal(test_data$Height[4:7], c(75, 75, 74, 71))

--- a/exercises/concept/trees-and-tibbleations/trees-and-tibbleations.R
+++ b/exercises/concept/trees-and-tibbleations/trees-and-tibbleations.R
@@ -2,7 +2,7 @@ library(datasets)
 
 tree_data <- NULL # your code here
 
-girth_n_weight <- function(data, dgts) {
+girth_n_weight <- function(data, rnd_digits) {
   
 }
 

--- a/exercises/concept/trees-and-tibbleations/trees-and-tibbleations.R
+++ b/exercises/concept/trees-and-tibbleations/trees-and-tibbleations.R
@@ -2,7 +2,7 @@ library(datasets)
 
 tree_data <- NULL # your code here
 
-girth_n_weight <- function(data, dgts=1) {
+girth_n_weight <- function(data, dgts) {
   
 }
 

--- a/exercises/concept/trees-and-tibbleations/trees-and-tibbleations.R
+++ b/exercises/concept/trees-and-tibbleations/trees-and-tibbleations.R
@@ -1,0 +1,15 @@
+library(datasets)
+
+tree_data <- NULL # your code here
+
+girth_n_weight <- function(data, dgts=1) {
+  
+}
+
+orchard_copy <- function(data, rearrangement) {
+  
+}
+
+customer_copy <- function(data, attributes, min_height, max_height, max_weight) {
+  
+}


### PR DESCRIPTION
Here's a first draft of a concept exercise for `Dataframes`. Some notes:

- The functions `all_of` and `pick` are useful/needed to complete the exercise.
  - It appears `all_of` is necessary due to: `external vector in selections was deprecated`.
  - `pick` appears to be necessary since `arrange` didn't like strings.
  - I could see including the latter in the `about.md` and `introduction.md`, but maybe not the former?
- I've included a trimmed down `introduction.md`, but it's still pretty lengthy.
- Testing is currently a bit weak, but likely sufficient. I'm just worried that if people order their columns differently somehow, this could lead to a failure.

I had considered adding another column with "location numbers", so that people could practice with the `relocate(.after)` option, but I figured this might be over complicating things. I'm certainly open to suggestions on how to refine things or what else needs to be included.

Please pay attention to the docs, since I went through many variable name changes and I may not have caught them all. Also, let me know if the instructions are clear enough with a believable story, since I didn't spend a long time thinking about them.