### PR TITLE
fix task numbering in tests

### DIFF
--- a/exercises/concept/trees-and-tibbleations/.docs/instructions.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/instructions.md
@@ -6,9 +6,9 @@ They have asked you to help code up some functionality to help in the tree selec
 
 ~~~~exercism/note
 The built-in [`datasets`][ref-datasets] library has many toy datasets, and this exercise uses the `trees` dataset.
-To call the dataset after the library is loaded, simply use the name `trees`.
+To call the dataset, simply use the name `trees`.
 ```R
-library(datasets)
+library(datasets) # loading is optional
 
 trees |> head(3)
 #>    A data.frame: 3 × 3 	
@@ -60,7 +60,7 @@ girth_n_weight(tree_data, 1) |> head(3)
 #>      8.8	     63	   10.2	  27.6	 357.0
 ```
 
-Note: For testing, the input dataset for `girth_n_weight` can be assumed to have `Diameter` and `Volume` columns.
+**Note:** For testing, the input dataset for `girth_n_weight` can be assumed to have `Diameter` and `Volume` columns.
 
 ## 3. Orchard copy of dataset
 
@@ -105,4 +105,4 @@ tree_data |>
 #>     69	 745.5	  36.8
 ```
 
-Note: For testing, the input dataset for `customer_copy` can be assumed to have `Height` and `Weight` columns.
+**Note:** For testing, the input dataset for `customer_copy` can be assumed to have `Height` and `Weight` columns.

--- a/exercises/concept/trees-and-tibbleations/.docs/introduction.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/introduction.md
@@ -310,7 +310,8 @@ For this reason, non-data-masking arguments (e.g. character vectors) need to be 
 A full treatment of how data-masking works in R is beyond the scope of this concept, but it's useful to know there are ways of making this conversion which include options such as: `pick()`, `.data[[]]` and `!!sym()`.
 
 ```R
-tbl |> arrange("languages") # arrange with string input fails silently
+ # arrange() with string input fails silently
+tbl |> arrange("languages")
 #>      A tibble: 4 × 3
 #>   languages created has.syllabus
 #>   <chr>       <dbl> <lgl>       

--- a/exercises/concept/trees-and-tibbleations/test_trees-and-tibbleations.R
+++ b/exercises/concept/trees-and-tibbleations/test_trees-and-tibbleations.R
@@ -25,7 +25,7 @@ test_that("3. Orchard copy of dataset", {
   expect_equal(test_data$Weight[5:9], c(745.5, 360.5, 899.5, 574.0, 1340.5))
 })
 
-test_that("3. Customer copy of dataset", {
+test_that("4. Customer copy of dataset", {
   test_data <- tree_data |> girth_n_weight(1) |> customer_copy(c('Weight', 'Height', 'Girth'), 70, 75, 1000)
 
   expect_equal(names(test_data), c('Weight', 'Height', 'Girth'))


### PR DESCRIPTION
In the tests, Task 4 was labeled with a 3, so I've fixed that and included a couple small fixes I noticed when seeing it on the website.

Indeed, `library(datasets)` doesn't need to be called, which I've mentioned in a comment, but I've left it in the stub for completeness.