### PR TITLE
added concept cross-links

### DIFF
--- a/concepts/functional-programming/about.md
+++ b/concepts/functional-programming/about.md
@@ -171,7 +171,9 @@ Resources to help navigate the library include:
 ~~~~exercism/note
 The `purrr` library operates almost entirely on 1-dimensional data: vectors and lists.
 
-We will see in a later concept that the `dplyr` library provides equivalent functionality for 2-D dataframes.
+We will see in a [later concept][concept-dataframes] that the `dplyr` library provides equivalent functionality for 2-D dataframes.
+
+[concept-dataframes]: https://exercism.org/tracks/r/concepts/dataframes
 ~~~~
 
 ### The many map functions
@@ -210,7 +212,7 @@ sum(1:100)
 ```
 
 In the above case, we convert a length-100 vector to a length-1 integer.
-We will see in a future Concept on matrices and arrays that the concept of dimension-reduction is more general.
+We will see in a future Concept on [matrices and arrays][concept-matrices-arrays] that the concept of dimension-reduction is more general.
 
 The `sum()` function is built in (as are many other statistical functions).
 However, we need a way to apply arbitrary dimension-reducing functions across a data structure, using some higher-order function equivalent to `map()`.
@@ -350,6 +352,7 @@ You can use recursion in R, and sometimes it is valuable, but there are often si
 [wiki-associative]: https://en.wikipedia.org/wiki/Associative_property
 [concept-vector-filtering]: https://exercism.org/tracks/r/concepts/vector-filtering
 [concept-vector-functions]: https://exercism.org/tracks/r/concepts/vector-functions
+[concept-matrices-arrays]: https://exercism.org/tracks/r/concepts/matrices-arrays
 [ref-predicates]: https://purrr.tidyverse.org/reference/index.html#predicate-functionals
 [ref-keep]: https://purrr.tidyverse.org/reference/keep.html
 [ref-every]: https://purrr.tidyverse.org/reference/every.html

--- a/concepts/randomness/about.md
+++ b/concepts/randomness/about.md
@@ -67,7 +67,7 @@ c(letters, LETTERS, 0:9) |> sample(50) |> str_flatten()
 ```
 
 Also, sampling is not limited to vectors and ranges.
-We will see in other concepts that [lists][concept-lists], matrices and dataframes are all valid inputs.
+We will see in other concepts that [lists][concept-lists], [matrices][concept-matrices-arrays] and [dataframes][concept-dataframes] are all valid inputs.
 *Exactly as you should expect for R*.
 
 ## Shuffling
@@ -335,4 +335,6 @@ Many statisticians and data scientists over the last few decades think that R fi
 [ref-rpois]: https://www.rdocumentation.org/packages/stats/versions/3.5.2/topics/Poisson
 [ref-set-seed]: https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/Random
 [concept-lists]: https://exercism.org/tracks/r/concepts/lists
+[concept-matrices-arrays]: https://exercism.org/tracks/r/concepts/matrices-arrays
+[concept-dataframes]: https://exercism.org/tracks/r/concepts/dataframes
 [practice-pascal]: https://exercism.org/tracks/r/exercises/pascals-triangle


### PR DESCRIPTION
A bit of housekeeping, adding links to other concepts. Most of the `about.md` docs are in better shape than I expected, but we can now refer to `dataframes` and `matrices-arrays` with links.