### PR TITLE
delete unwanted links from hints

### DIFF
--- a/exercises/concept/trees-and-tibbleations/.docs/hints.md
+++ b/exercises/concept/trees-and-tibbleations/.docs/hints.md
@@ -20,7 +20,3 @@
 
 - You will need to take a subset of columns.
 - Only the trees between the minimum and maximum height *and* below the maximum weight should be in the copy.
-
-[ref-allof]: https://tidyselect.r-lib.org/reference/all_of.html
-[ref-pick]: https://dplyr.tidyverse.org/reference/pick.html
-[ref-datamask]: https://rlang.r-lib.org/reference/args_data_masking.html


### PR DESCRIPTION
A trivial bit of cleanup: with data masking removed from the exercise we no longer need the references.

Mostly, I'm still trying to prod the website to add this to the syllabus.