### PR TITLE
Missing templates

### DIFF
--- a/bin/missing-templates
+++ b/bin/missing-templates
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# 
+# find exercises without a generator template (or txt file)
+# exclude deprecated exercises
+# exclude exercises with no canonical data
+
+filter_deprecated() {
+    grep -vFxf <(
+        jq -r '.exercises.practice[] | select(.status == "deprecated") | .slug' config.json
+    )
+}
+
+filter_canonical() {
+    local probspec="${XDG_CACHE_HOME:-$HOME/.cache}/exercism/configlet/problem-specifications"
+    if [[ -d $probspec ]]; then
+        grep -vFxf <(
+            find "$probspec/exercises" -mindepth 1 -type d \
+                \! -exec test -f '{}/canonical-data.json' \; \
+                -exec basename '{}' \;
+        )
+    else
+        cat
+    fi
+}
+
+find exercises/practice/ -mindepth 2 -type d -path '*/.meta' \! -exec bash -c '[[ -f "$0"/template.j2 || -f "$0"/template.txt ]]' '{}' \; -print \
+| cut -d / -f 3 \
+| filter_deprecated \
+| filter_canonical \
+| sort

--- a/exercises/practice/hello-world/.meta/template.txt
+++ b/exercises/practice/hello-world/.meta/template.txt
@@ -1,0 +1,1 @@
+Honestly, why would you template this one?

--- a/exercises/practice/simple-cipher/.meta/template.txt
+++ b/exercises/practice/simple-cipher/.meta/template.txt
@@ -1,0 +1,5 @@
+Opting not to template this one.
+
+It is possible (see the Python track), but really messy and complicated. 
+
+I (@colinleach) just did a partial template for Julia, and it's more trouble than it's worth.


### PR DESCRIPTION
This is a little utility that Glenn wrote (for TCL).

Just run `bin/missing-templates` in a shell, and it lists practice exercises which could need a template.

Excludes:
- Deprecated exercises
- Exercises without canonical data
- Exercises with a `.meta/template.txt` file: which can be used to give a short explanation, as in the two examples here.

I'll also add this to Julia, though I think nearly all of those are still missing.