### PR TITLE
Affine cipher

### DIFF
--- a/config.json
+++ b/config.json
@@ -1107,6 +1107,14 @@
         "difficulty": 4
       },
       {
+        "slug": "affine-cipher",
+        "name": "Affine Cipher",
+        "uuid": "478b838b-dc33-4532-984c-281c0c2424b8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
         "slug": "say",
         "name": "Say",
         "uuid": "c87b10f2-0920-4fdc-9143-a879708b24f2",
@@ -1212,14 +1220,6 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8
-      },
-      {
-        "slug": "affine-cipher",
-        "name": "Affine Cipher",
-        "uuid": "478b838b-dc33-4532-984c-281c0c2424b8",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -1212,6 +1212,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8
+      },
+      {
+        "slug": "affine-cipher",
+        "name": "Affine Cipher",
+        "uuid": "478b838b-dc33-4532-984c-281c0c2424b8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
       }
     ]
   },

--- a/exercises/practice/affine-cipher/.docs/instructions.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.md
@@ -1,0 +1,74 @@
+# Instructions
+
+Create an implementation of the affine cipher, an ancient encryption system created in the Middle East.
+
+The affine cipher is a type of monoalphabetic substitution cipher.
+Each character is mapped to its numeric equivalent, encrypted with a mathematical function and then converted to the letter relating to its new numeric value.
+Although all monoalphabetic ciphers are weak, the affine cipher is much stronger than the Atbash cipher, because it has many more keys.
+
+[//]: # " monoalphabetic as spelled by Merriam-Webster, compare to polyalphabetic "
+
+## Encryption
+
+The encryption function is:
+
+```text
+E(x) = (ai + b) mod m
+```
+
+Where:
+
+- `i` is the letter's index from `0` to the length of the alphabet - 1.
+- `m` is the length of the alphabet.
+  For the Latin alphabet `m` is `26`.
+- `a` and `b` are integers which make up the encryption key.
+
+Values `a` and `m` must be _coprime_ (or, _relatively prime_) for automatic decryption to succeed, i.e., they have number `1` as their only common factor (more information can be found in the [Wikipedia article about coprime integers][coprime-integers]).
+In case `a` is not coprime to `m`, your program should indicate that this is an error.
+Otherwise it should encrypt or decrypt with the provided key.
+
+For the purpose of this exercise, digits are valid input but they are not encrypted.
+Spaces and punctuation characters are excluded.
+Ciphertext is written out in groups of fixed length separated by space, the traditional group size being `5` letters.
+This is to make it harder to guess encrypted text based on word boundaries.
+
+## Decryption
+
+The decryption function is:
+
+```text
+D(y) = (a^-1)(y - b) mod m
+```
+
+Where:
+
+- `y` is the numeric value of an encrypted letter, i.e., `y = E(x)`
+- it is important to note that `a^-1` is the modular multiplicative inverse (MMI) of `a mod m`
+- the modular multiplicative inverse only exists if `a` and `m` are coprime.
+
+The MMI of `a` is `x` such that the remainder after dividing `ax` by `m` is `1`:
+
+```text
+ax mod m = 1
+```
+
+More information regarding how to find a Modular Multiplicative Inverse and what it means can be found in the [related Wikipedia article][mmi].
+
+## General Examples
+
+- Encrypting `"test"` gives `"ybty"` with the key `a = 5`, `b = 7`
+- Decrypting `"ybty"` gives `"test"` with the key `a = 5`, `b = 7`
+- Decrypting `"ybty"` gives `"lqul"` with the wrong key `a = 11`, `b = 7`
+- Decrypting `"kqlfd jzvgy tpaet icdhm rtwly kqlon ubstx"` gives `"thequickbrownfoxjumpsoverthelazydog"` with the key `a = 19`, `b = 13`
+- Encrypting `"test"` with the key `a = 18`, `b = 13` is an error because `18` and `26` are not coprime
+
+## Example of finding a Modular Multiplicative Inverse (MMI)
+
+Finding MMI for `a = 15`:
+
+- `(15 * x) mod 26 = 1`
+- `(15 * 7) mod 26 = 1`, ie. `105 mod 26 = 1`
+- `7` is the MMI of `15 mod 26`
+
+[mmi]: https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
+[coprime-integers]: https://en.wikipedia.org/wiki/Coprime_integers

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "colinleach"
+  ],
+  "files": {
+    "solution": [
+      "affine-cipher.R"
+    ],
+    "test": [
+      "test_affine-cipher.R"
+    ],
+    "example": [
+      ".meta/example.R"
+    ]
+  },
+  "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Affine_cipher"
+}

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -2,6 +2,10 @@
   "authors": [
     "colinleach"
   ],
+  "contributors": [
+    "katrinleinweber",
+    "tintinthong"
+  ],
   "files": {
     "solution": [
       "affine-cipher.R"

--- a/exercises/practice/affine-cipher/.meta/example.R
+++ b/exercises/practice/affine-cipher/.meta/example.R
@@ -1,0 +1,49 @@
+library(stringr)
+library(purrr)
+
+gcd <- function(x, y) {
+  r <- x %% y
+  ifelse(r, gcd(y, r), y)
+}
+
+mmi <- function(a, m) {
+  a <- a %% m
+  for (x in 1:m) {
+    if ((a * x) %% m == 1) return(x)
+  }
+  1
+}
+
+translate <- function(phrase, a, b, mode) {
+  m <- 26
+  stopifnot(gcd(a, m) == 1)
+  stopifnot(mode %in% c(0, 1))
+
+  process_char <- function(c) {
+    if (c %in% "0":"9") return(c)
+
+    inx_c <- utf8ToInt(c) - utf8ToInt("a")
+    new_c <- ifelse(mode == 0, a * inx_c + b, mmi(a, m) * (inx_c - b))
+    intToUtf8(new_c %% m + utf8ToInt("a"))
+  }
+
+  phrase |>
+    str_to_lower() |>
+    str_replace_all("[^a-z0-9]", "") |>
+    str_split_1("") |>
+    map_chr(process_char) |>
+    str_flatten()
+}
+
+encode <- function(plaintext, a, b) {
+  plaintext |>
+    translate(a, b, mode = 0) |>
+    str_match_all(".{1,5}") |>
+    unlist() |>
+    str_c(collapse = " ")
+}
+
+decode <- function(ciphertext, a, b) {
+  ciphertext |>
+    translate(a, b, mode = 1)
+}

--- a/exercises/practice/affine-cipher/.meta/template.j2
+++ b/exercises/practice/affine-cipher/.meta/template.j2
@@ -1,0 +1,20 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header() }}
+
+{% for case in cases %}
+# {{ case["description"] }}
+  {% for subcase in case["cases"] %}
+test_that("{{ subcase["description"] }}", {
+  {%- if subcase["expected"]["error"] -%}
+  expect_error({{ subcase["property"] }}("{{ subcase["input"]["phrase"] }}", 
+                      {{ subcase["input"]["key"]["a"] }}, {{ subcase["input"]["key"]["b"] }}))
+  {%- else -%}
+  expect_equal({{ subcase["property"] }}("{{ subcase["input"]["phrase"] }}", 
+                      {{ subcase["input"]["key"]["a"] }}, {{ subcase["input"]["key"]["b"] }}), 
+                      "{{ subcase["expected"] }}")
+  {%- endif -%}
+})
+  {% endfor %}
+{% endfor %}

--- a/exercises/practice/affine-cipher/.meta/tests.toml
+++ b/exercises/practice/affine-cipher/.meta/tests.toml
@@ -1,0 +1,58 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a]
+description = "encode -> encode yes"
+
+[785bade9-e98b-4d4f-a5b0-087ba3d7de4b]
+description = "encode -> encode no"
+
+[2854851c-48fb-40d8-9bf6-8f192ed25054]
+description = "encode -> encode OMG"
+
+[bc0c1244-b544-49dd-9777-13a770be1bad]
+description = "encode -> encode O M G"
+
+[381a1a20-b74a-46ce-9277-3778625c9e27]
+description = "encode -> encode mindblowingly"
+
+[6686f4e2-753b-47d4-9715-876fdc59029d]
+description = "encode -> encode numbers"
+
+[ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3]
+description = "encode -> encode deep thought"
+
+[c93a8a4d-426c-42ef-9610-76ded6f7ef57]
+description = "encode -> encode all the letters"
+
+[0673638a-4375-40bd-871c-fb6a2c28effb]
+description = "encode -> encode with a not coprime to m"
+
+[3f0ac7e2-ec0e-4a79-949e-95e414953438]
+description = "decode -> decode exercism"
+
+[241ee64d-5a47-4092-a5d7-7939d259e077]
+description = "decode -> decode a sentence"
+
+[33fb16a1-765a-496f-907f-12e644837f5e]
+description = "decode -> decode numbers"
+
+[20bc9dce-c5ec-4db6-a3f1-845c776bcbf7]
+description = "decode -> decode all the letters"
+
+[623e78c0-922d-49c5-8702-227a3e8eaf81]
+description = "decode -> decode with no spaces in input"
+
+[58fd5c2a-1fd9-4563-a80a-71cff200f26f]
+description = "decode -> decode with too many spaces"
+
+[b004626f-c186-4af9-a3f4-58f74cdb86d5]
+description = "decode -> decode with a not coprime to m"

--- a/exercises/practice/affine-cipher/affine-cipher.R
+++ b/exercises/practice/affine-cipher/affine-cipher.R
@@ -1,13 +1,5 @@
 library(stringr)
-
-normalise <- function(text) {
-  tolower(gsub(" ", "", text))
-}
-
-lookupindex <- function(normalisedtext) {
-  letterslist <- strsplit(normalisedtext, "")[[1]]
-  match(letterslist, letters) - 1
-}
+library(purrr)
 
 gcd <- function(x, y) {
   r <- x %% y
@@ -17,38 +9,41 @@ gcd <- function(x, y) {
 mmi <- function(a, m) {
   a <- a %% m
   for (x in 1:m) {
-    if ((a * x) %% m == 1) {
-      return(x)
-    }
+    if ((a * x) %% m == 1) return(x)
   }
   1
 }
 
 translate <- function(phrase, a, b, mode) {
-  
+  m <- 26
+  stopifnot(gcd(a, m) == 1)
+  stopifnot(mode %in% c(0, 1))
+
+  process_char <- function(c) {
+    if (c %in% "0":"9") return(c)
+
+    inx_c <- utf8ToInt(c) - utf8ToInt("a")
+    new_c <- ifelse(mode == 0, a * inx_c + b, mmi(a, m) * (inx_c - b))
+    intToUtf8(new_c %% m + utf8ToInt("a"))
+  }
+
+  phrase |>
+    str_to_lower() |>
+    str_replace_all("[^a-z0-9]", "") |>
+    str_split_1("") |>
+    map_chr(process_char) |>
+    str_flatten()
 }
 
 encode <- function(plaintext, a, b) {
-  m <- 26
-
-  if (gcd(a, m) != 1) {
-    stop("a and m must be co-prime")
-  }
-
-  x <- plaintext |> normalise() |> lookupindex()
-
-  text <- paste(letters[ ((a * x + b) %% m) + 1], collapse = "")
-  str_match_all(text, ".{1,5}")[[1]] |> str_c(collapse = " ")
+  plaintext |>
+    translate(a, b, mode = 0) |>
+    str_match_all(".{1,5}") |>
+    unlist() |>
+    str_c(collapse = " ")
 }
 
 decode <- function(ciphertext, a, b) {
-  m <- 26
-
-  if (gcd(a, m) != 1) {
-    stop("a and m must be co-prime")
-  }
-
-  y <- ciphertext |> normalise() |> lookupindex()
-
-  paste(letters[((mmi(a, m) * (y - b)) %% m) + 1], collapse = "")
+  ciphertext |>
+    translate(a, b, mode = 1)
 }

--- a/exercises/practice/affine-cipher/affine-cipher.R
+++ b/exercises/practice/affine-cipher/affine-cipher.R
@@ -1,0 +1,54 @@
+library(stringr)
+
+normalise <- function(text) {
+  tolower(gsub(" ", "", text))
+}
+
+lookupindex <- function(normalisedtext) {
+  letterslist <- strsplit(normalisedtext, "")[[1]]
+  match(letterslist, letters) - 1
+}
+
+gcd <- function(x, y) {
+  r <- x %% y
+  ifelse(r, gcd(y, r), y)
+}
+
+mmi <- function(a, m) {
+  a <- a %% m
+  for (x in 1:m) {
+    if ((a * x) %% m == 1) {
+      return(x)
+    }
+  }
+  1
+}
+
+translate <- function(phrase, a, b, mode) {
+  
+}
+
+encode <- function(plaintext, a, b) {
+  m <- 26
+
+  if (gcd(a, m) != 1) {
+    stop("a and m must be co-prime")
+  }
+
+  x <- plaintext |> normalise() |> lookupindex()
+
+  text <- paste(letters[ ((a * x + b) %% m) + 1], collapse = "")
+  str_match_all(text, ".{1,5}")[[1]] |> str_c(collapse = " ")
+}
+
+decode <- function(ciphertext, a, b) {
+  m <- 26
+
+  if (gcd(a, m) != 1) {
+    stop("a and m must be co-prime")
+  }
+
+  y <- ciphertext |> normalise() |> lookupindex()
+
+  paste(letters[((mmi(a, m) * (y - b)) %% m) + 1], collapse = "")
+}

--- a/exercises/practice/affine-cipher/affine-cipher.R
+++ b/exercises/practice/affine-cipher/affine-cipher.R
@@ -1,49 +1,7 @@
-library(stringr)
-library(purrr)
-
-gcd <- function(x, y) {
-  r <- x %% y
-  ifelse(r, gcd(y, r), y)
-}
-
-mmi <- function(a, m) {
-  a <- a %% m
-  for (x in 1:m) {
-    if ((a * x) %% m == 1) return(x)
-  }
-  1
-}
-
-translate <- function(phrase, a, b, mode) {
-  m <- 26
-  stopifnot(gcd(a, m) == 1)
-  stopifnot(mode %in% c(0, 1))
-
-  process_char <- function(c) {
-    if (c %in% "0":"9") return(c)
-
-    inx_c <- utf8ToInt(c) - utf8ToInt("a")
-    new_c <- ifelse(mode == 0, a * inx_c + b, mmi(a, m) * (inx_c - b))
-    intToUtf8(new_c %% m + utf8ToInt("a"))
-  }
-
-  phrase |>
-    str_to_lower() |>
-    str_replace_all("[^a-z0-9]", "") |>
-    str_split_1("") |>
-    map_chr(process_char) |>
-    str_flatten()
-}
-
 encode <- function(plaintext, a, b) {
-  plaintext |>
-    translate(a, b, mode = 0) |>
-    str_match_all(".{1,5}") |>
-    unlist() |>
-    str_c(collapse = " ")
+
 }
 
 decode <- function(ciphertext, a, b) {
-  ciphertext |>
-    translate(a, b, mode = 1)
+
 }

--- a/exercises/practice/affine-cipher/test_affine-cipher.R
+++ b/exercises/practice/affine-cipher/test_affine-cipher.R
@@ -1,0 +1,88 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/affine-cipher/canonical-data.json
+# File last updated on 2026-08-28
+
+source("./affine-cipher.R")
+library(testthat)
+
+
+# encode
+
+test_that("encode yes", {
+  expect_equal(encode("yes", 5, 7), "xbt")
+})
+
+test_that("encode no", {
+  expect_equal(encode("no", 15, 18), "fu")
+})
+
+test_that("encode OMG", {
+  expect_equal(encode("OMG", 21, 3), "lvz")
+})
+
+test_that("encode O M G", {
+  expect_equal(encode("O M G", 25, 47), "hjp")
+})
+
+test_that("encode mindblowingly", {
+  expect_equal(encode("mindblowingly", 11, 15), "rzcwa gnxzc dgt")
+})
+
+test_that("encode numbers", {
+  expect_equal(encode("Testing,1 2 3, testing.", 3, 4), "jqgjc rw123 jqgjc rw")
+})
+
+test_that("encode deep thought", {
+  expect_equal(encode("Truth is fiction.", 5, 17), "iynia fdqfb ifje")
+})
+
+test_that("encode all the letters", {
+  expect_equal(
+    encode("The quick brown fox jumps over the lazy dog.", 17, 33),
+    "swxtj npvyk lruol iejdc blaxk swxmh qzglf"
+  )
+})
+
+test_that("encode with a not coprime to m", {
+  expect_error(encode("This is a test.", 6, 17))
+})
+
+
+# decode
+
+test_that("decode exercism", {
+  expect_equal(decode("tytgn fjr", 3, 7), "exercism")
+})
+
+test_that("decode a sentence", {
+  expect_equal(
+    decode("qdwju nqcro muwhn odqun oppmd aunwd o", 19, 16),
+    "anobstacleisoftenasteppingstone"
+  )
+})
+
+test_that("decode numbers", {
+  expect_equal(decode("odpoz ub123 odpoz ub", 25, 7), "testing123testing")
+})
+
+test_that("decode all the letters", {
+  expect_equal(
+    decode("swxtj npvyk lruol iejdc blaxk swxmh qzglf", 17, 33),
+    "thequickbrownfoxjumpsoverthelazydog"
+  )
+})
+
+test_that("decode with no spaces in input", {
+  expect_equal(
+    decode("swxtjnpvyklruoliejdcblaxkswxmhqzglf", 17, 33),
+    "thequickbrownfoxjumpsoverthelazydog"
+  )
+})
+
+test_that("decode with too many spaces", {
+  expect_equal(decode("vszzm    cly   yd cg    qdp", 15, 16), "jollygreengiant")
+})
+
+test_that("decode with a not coprime to m", {
+  expect_error(decode("Test", 13, 5))
+})


### PR DESCRIPTION
Replaces #125, which addresses a much earlier version of this exercise.

In the end, not much of the original code survived to the working solution.

Necessary changes:
- Numerical digits are now passed through unchanged.
- Output from `encode()` is in 5-character chunks.

Optional changes:
- Functional design with `stringr`, `purrr` and lots of pipes.
- Refactoring to reduce code duplication.

I'm undecided between difficulty 4 or 5. This was discussed (without resolution?) in #125, and other tracks vary widely. Whatever, I think it's somewhere in the Medium range.

I'll also create a Julia version, while I remember where the various gotchas are.